### PR TITLE
User Settings endpoints

### DIFF
--- a/dbconnection.ts
+++ b/dbconnection.ts
@@ -36,11 +36,15 @@ export const hasResults = async (
 };
 
 /**
- * Queries
- * @param conn
- * @param query
- * @param args
- * @returns
+ * Loads a list of results from the database given a sql query and casts the result to `Value`.
+ *
+ * @example
+ * ```ts
+ * type User = { id: string, ... }
+ *
+ * const results = await queryResults<User>(conn, "SELECT * FROM user");
+ * console.log(results.id) // ✅ Typesafe
+ * ```
  */
 export const queryResults = async <Value>(
   conn: SQLExecutable,

--- a/dbconnection.ts
+++ b/dbconnection.ts
@@ -1,6 +1,7 @@
 import { ExecutedQuery, connect } from "@planetscale/database";
 import fetch from "node-fetch";
 import { envVars } from "./env";
+
 /**
  * The main planet scale connection to use.
  */
@@ -43,7 +44,7 @@ export const hasResults = async (
  * type User = { id: string, ... }
  *
  * const results = await queryResults<User>(conn, "SELECT * FROM user");
- * console.log(results.id) // ✅ Typesafe
+ * console.log(results[0].id) // ✅ Typesafe
  * ```
  */
 export const queryResults = async <Value>(
@@ -52,4 +53,26 @@ export const queryResults = async <Value>(
   args: object | any[] | null = null
 ) => {
   return await conn.execute(query, args).then((res) => res.rows as Value[]);
+};
+
+/**
+ * Returns the first result of a query in a typesafe manner.
+ *
+ * @example
+ * ```ts
+ * type User = { id: string, ... }
+ *
+ * const result? = await queryFirst<User>(conn, "SELECT * FROM user");
+ * console.log(result?.id) // ✅ Typesafe
+ * ```
+ */
+export const queryFirst = async <Value>(
+  conn: SQLExecutable,
+  query: string,
+  args: object | any[] | null = null
+) => {
+  return await conn.execute(query, args).then((res) => {
+    // NB: We'll cast this to undefined because that's what js likes to do without telling us...
+    return res.rows[0] as Value | undefined;
+  });
 };

--- a/dbconnection.ts
+++ b/dbconnection.ts
@@ -1,12 +1,24 @@
-import { ExecutedQuery, connect } from "@planetscale/database";
+import { ExecutedQuery, connect, Field, cast } from "@planetscale/database";
 import fetch from "node-fetch";
 import { envVars } from "./env";
+
+/**
+ * A cast function that turns all INT8 types into booleans.
+ * This exists solely because of the tinyint type in MySQL.
+ */
+export const int8ToBoolCast = (field: Field, value: string | null) => {
+  if (field.type === "INT8") {
+    return parseInt(value ?? "0") > 0;
+  }
+  return cast(field, value);
+};
 
 /**
  * The main planet scale connection to use.
  */
 export const conn = connect({
   fetch,
+  cast: int8ToBoolCast, // NB: Should we use this as the global caster?
   host: envVars.DATABASE_HOST,
   username: envVars.DATABASE_USERNAME,
   password: envVars.DATABASE_PASSWORD,

--- a/test/database.ts
+++ b/test/database.ts
@@ -6,6 +6,7 @@ const resetDB = async () => {
     await tx.execute("DELETE FROM user");
     await tx.execute("DELETE FROM Event");
     await tx.execute("DELETE FROM userRelations");
+    await tx.execute("DELETE FROM userSettings");
   });
 };
 

--- a/test/users.test.ts
+++ b/test/users.test.ts
@@ -133,14 +133,15 @@ describe("Users tests", () => {
 
   describe("GetSelf tests", () => {
     it("404s when you have no account", async () => {
-      const resp = await request(app)
-        .get("/user/self")
-        .set("Authorization", randomUUID())
-        .send();
+      const resp = await fetchSelf(randomUUID());
       expect(resp.status).toEqual(404);
       expect(resp.body).toMatchObject({ error: "user-not-found" });
     });
   });
+
+  const fetchSelf = async (id: string) => {
+    return await request(app).get("/user/self").set("Authorization", id).send();
+  };
 
   const friendUser = async (user1Id: string, user2Id: string) => {
     return await request(app)

--- a/test/users.test.ts
+++ b/test/users.test.ts
@@ -4,7 +4,7 @@ import {
   resetDatabaseBeforeEach,
 } from "./database";
 import { conn } from "../dbconnection";
-import { InsertUserRequest, insertUser } from "../users";
+import { RegisterUserRequest, insertUser } from "../users";
 import request from "supertest";
 import { createTestApp } from "./testApp";
 
@@ -137,6 +137,28 @@ describe("Users tests", () => {
       expect(resp.status).toEqual(404);
       expect(resp.body).toMatchObject({ error: "user-not-found" });
     });
+
+    it("should be able to fetch your private account info", async () => {
+      const id = randomUUID();
+      const accountInfo = {
+        id,
+        name: "Matthew Hayes",
+        handle: "little_chungus",
+      };
+      await registerUser(accountInfo);
+      const resp = await fetchSelf(id);
+
+      expect(resp.status).toEqual(200);
+      expect(resp.body).toMatchObject(
+        expect.objectContaining({
+          ...accountInfo,
+          bio: null,
+          updatedAt: null,
+          profileImageURL: null,
+        })
+      );
+      expect(Date.parse(resp.body.creationDate)).not.toBeNaN();
+    });
   });
 
   const fetchSelf = async (id: string) => {
@@ -150,7 +172,7 @@ describe("Users tests", () => {
       .send();
   };
 
-  const registerUser = async (req: InsertUserRequest) => {
+  const registerUser = async (req: RegisterUserRequest) => {
     return await request(app).post("/user").set("Authorization", req.id).send({
       name: req.name,
       handle: req.handle,

--- a/test/users.test.ts
+++ b/test/users.test.ts
@@ -6,9 +6,9 @@ import {
 import { conn } from "../dbconnection";
 import {
   RegisterUserRequest,
-  USER_NOT_FOUND_BODY,
   UserSettings,
   insertUser,
+  userNotFoundBody,
 } from "../users";
 import request from "supertest";
 import { createTestApp } from "./testApp";
@@ -139,9 +139,10 @@ describe("Users tests", () => {
 
   describe("GetSelf tests", () => {
     it("404s when you have no account", async () => {
-      const resp = await fetchSelf(randomUUID());
+      const id = randomUUID();
+      const resp = await fetchSelf(id);
       expect(resp.status).toEqual(404);
-      expect(resp.body).toMatchObject({ error: "user-not-found" });
+      expect(resp.body).toMatchObject(userNotFoundBody(id));
     });
 
     it("should be able to fetch your private account info", async () => {
@@ -169,9 +170,10 @@ describe("Users tests", () => {
 
   describe("Settings tests", () => {
     it("should 404 when gettings settings when user does not exist", async () => {
-      const resp = await fetchSettings(randomUUID());
+      const id = randomUUID();
+      const resp = await fetchSettings(id);
       expect(resp.status).toEqual(404);
-      expect(resp.body).toEqual(USER_NOT_FOUND_BODY);
+      expect(resp.body).toEqual(userNotFoundBody(id));
     });
 
     it("should return the default settings when settings not edited", async () => {
@@ -190,11 +192,10 @@ describe("Users tests", () => {
     });
 
     it("should 404 when attempting edit settings for non-existent user", async () => {
-      const resp = await editSettings(randomUUID(), {
-        isAnalyticsEnabled: false,
-      });
+      const id = randomUUID();
+      const resp = await editSettings(id, { isAnalyticsEnabled: false });
       expect(resp.status).toEqual(404);
-      expect(resp.body).toMatchObject(USER_NOT_FOUND_BODY);
+      expect(resp.body).toMatchObject(userNotFoundBody(id));
     });
 
     const registerTestUser = async () => {

--- a/test/users.test.ts
+++ b/test/users.test.ts
@@ -131,6 +131,17 @@ describe("Users tests", () => {
     });
   });
 
+  describe("GetSelf tests", () => {
+    it("404s when you have no account", async () => {
+      const resp = await request(app)
+        .get("/user/self")
+        .set("Authorization", randomUUID())
+        .send();
+      expect(resp.status).toEqual(404);
+      expect(resp.body).toMatchObject({ error: "user-not-found" });
+    });
+  });
+
   const friendUser = async (user1Id: string, user2Id: string) => {
     return await request(app)
       .post(`/user/friend/${user2Id}`)

--- a/test/users.test.ts
+++ b/test/users.test.ts
@@ -198,6 +198,23 @@ describe("Users tests", () => {
       expect(resp.body).toMatchObject(userNotFoundBody(id));
     });
 
+    it("should be able to retrieve the user's edited settings", async () => {
+      const id = await registerTestUser();
+      await editSettings(id, { isChatNotificationsEnabled: false });
+      await editSettings(id, { isCrashReportingEnabled: false });
+
+      const resp = await fetchSettings(id);
+      expect(resp.status).toEqual(200);
+      expect(resp.body).toMatchObject({
+        isAnalyticsEnabled: true,
+        isCrashReportingEnabled: false,
+        isEventNotificationsEnabled: true,
+        isMentionsNotificationsEnabled: true,
+        isChatNotificationsEnabled: false,
+        isFriendRequestNotificationsEnabled: true,
+      });
+    });
+
     const registerTestUser = async () => {
       const id = randomUUID();
       await registerUser({ id, name: "test", handle: "test" });

--- a/test/users.test.ts
+++ b/test/users.test.ts
@@ -168,6 +168,22 @@ describe("Users tests", () => {
       expect(resp.status).toEqual(404);
       expect(resp.body).toEqual({ error: "user-not-found" });
     });
+
+    it("should return the default settings when settings not edited", async () => {
+      const id = randomUUID();
+      await registerUser({ id, name: "test", handle: "test" });
+
+      const resp = await fetchSettings(id);
+      expect(resp.status).toEqual(200);
+      expect(resp.body).toEqual({
+        isAnalyticsEnabled: true,
+        isCrashReportingEnabled: true,
+        isEventNotificationsEnabled: true,
+        isMentionsNotificationsEnabled: true,
+        isChatNotificationsEnabled: true,
+        isFriendRequestNotificationsEnabled: true,
+      });
+    });
   });
 
   const fetchSettings = async (id: string) => {

--- a/test/users.test.ts
+++ b/test/users.test.ts
@@ -162,6 +162,21 @@ describe("Users tests", () => {
     });
   });
 
+  describe("Settings tests", () => {
+    it("should 404 when gettings settings when user does not exist", async () => {
+      const resp = await fetchSettings(randomUUID());
+      expect(resp.status).toEqual(404);
+      expect(resp.body).toEqual({ error: "user-not-found" });
+    });
+  });
+
+  const fetchSettings = async (id: string) => {
+    return await request(app)
+      .get("/user/self/settings")
+      .set("Authorization", id)
+      .send();
+  };
+
   const fetchSelf = async (id: string) => {
     return await request(app).get("/user/self").set("Authorization", id).send();
   };

--- a/test/users.test.ts
+++ b/test/users.test.ts
@@ -215,6 +215,15 @@ describe("Users tests", () => {
       });
     });
 
+    it("should 400 invalid settings body when updating settings", async () => {
+      const id = await registerTestUser();
+      const resp = await request(app)
+        .patch("/user/self/settings")
+        .set("Authorization", id)
+        .send({ isAnalyticsEnabled: 69, hello: "world" });
+      expect(resp.status).toEqual(400);
+    });
+
     const registerTestUser = async () => {
       const id = randomUUID();
       await registerUser({ id, name: "test", handle: "test" });

--- a/test/users.test.ts
+++ b/test/users.test.ts
@@ -125,6 +125,7 @@ describe("Users tests", () => {
 
     it("should have a friend status when the receiver sends a friend request to someone who sent them a pending friend request", async () => {
       await friendUser(youId, otherId);
+
       const resp = await friendUser(otherId, youId);
       expect(resp.status).toEqual(201);
       expect(resp.body).toMatchObject({ status: "friends" });

--- a/users.ts
+++ b/users.ts
@@ -58,6 +58,10 @@ export const createUserRouter = (environment: ServerEnvironment) => {
     });
   });
 
+  router.get("/self", async (_, res) => {
+    return res.status(404).json({ error: "user-not-found" });
+  });
+
   return router;
 };
 

--- a/users.ts
+++ b/users.ts
@@ -11,8 +11,10 @@ import { z } from "zod";
 import { Result } from "./utils";
 import { Connection } from "@planetscale/database";
 
+export const USER_NOT_FOUND_BODY = { error: "user-not-found" };
+
 const userNotFoundResponse = (res: Response) => {
-  res.status(404).json({ error: "user-not-found" });
+  res.status(404).json(USER_NOT_FOUND_BODY);
 };
 
 /**
@@ -66,6 +68,10 @@ export const createUserRouter = (environment: ServerEnvironment) => {
       return userNotFoundResponse(res);
     }
     return res.status(200).json(settings);
+  });
+
+  router.patch("/self/settings", async (_, res) => {
+    return userNotFoundResponse(res);
   });
 
   return router;
@@ -244,9 +250,7 @@ const userWithHandleExists = async (conn: SQLExecutable, handle: string) => {
   return await hasResults(
     conn,
     "SELECT TRUE FROM user WHERE handle = :handle",
-    {
-      handle,
-    }
+    { handle }
   );
 };
 

--- a/users.ts
+++ b/users.ts
@@ -11,10 +11,13 @@ import { z } from "zod";
 import { Result } from "./utils";
 import { Connection } from "@planetscale/database";
 
-export const USER_NOT_FOUND_BODY = { error: "user-not-found" };
+export const userNotFoundBody = (userId: string) => ({
+  userId,
+  error: "user-not-found",
+});
 
-const userNotFoundResponse = (res: Response) => {
-  res.status(404).json(USER_NOT_FOUND_BODY);
+export const userNotFoundResponse = (res: Response, userId: string) => {
+  res.status(404).json(userNotFoundBody(userId));
 };
 
 /**
@@ -54,7 +57,7 @@ export const createUserRouter = (environment: ServerEnvironment) => {
   router.get("/self", async (_, res) => {
     const user = await userWithId(environment.conn, res.locals.selfId);
     if (!user) {
-      return userNotFoundResponse(res);
+      return userNotFoundResponse(res, res.locals.selfId);
     }
     return res.status(200).json(user);
   });
@@ -65,13 +68,13 @@ export const createUserRouter = (environment: ServerEnvironment) => {
       res.locals.selfId
     );
     if (!settings) {
-      return userNotFoundResponse(res);
+      return userNotFoundResponse(res, res.locals.selfId);
     }
     return res.status(200).json(settings);
   });
 
   router.patch("/self/settings", async (_, res) => {
-    return userNotFoundResponse(res);
+    return userNotFoundResponse(res, res.locals.selfId);
   });
 
   return router;

--- a/users.ts
+++ b/users.ts
@@ -76,10 +76,10 @@ export const createUserRouter = (environment: ServerEnvironment) => {
     await withValidatedRequest(
       req,
       res,
-      WriteUserSettingsRequestSchema,
+      PatchUserSettingsRequestSchema,
       async (data) => {
         const result = await environment.conn.transaction(async (tx) => {
-          return await writeUserSettings(tx, res.locals.selfId, data.body);
+          return await overwriteUserSettings(tx, res.locals.selfId, data.body);
         });
         if (result.status === "error") {
           return userNotFoundResponse(res, res.locals.selfId);
@@ -121,11 +121,11 @@ export const DEFAULT_USER_SETTINGS = {
   isFriendRequestNotificationsEnabled: true,
 } as const;
 
-const WriteUserSettingsRequestSchema = z.object({
+const PatchUserSettingsRequestSchema = z.object({
   body: UserSettingsSchema.partial(),
 });
 
-const writeUserSettings = async (
+const overwriteUserSettings = async (
   conn: SQLExecutable,
   userId: string,
   settings: Partial<UserSettings>

--- a/utils.ts
+++ b/utils.ts
@@ -1,0 +1,3 @@
+export type Result<Success, Error> =
+  | { status: "success"; value: Success }
+  | { status: "error"; value: Error };

--- a/utils.ts
+++ b/utils.ts
@@ -1,3 +1,39 @@
+/**
+ * A union type that represents either the case of a success or an error.
+ *
+ * @example
+ * ```ts
+ * // Usage when returning from a function
+ * const registerNewUser = async (
+ *   conn: Connection,
+ *   request: RegisterUserRequest
+ * ): Promise<
+ *   Result<{ id: string }, "user-already-exists" | "duplicate-handle">
+ * > => {
+ *   return await conn.transaction(async (tx) => {
+ *     if (await userWithIdExists(tx, request.id)) {
+ *       return { status: "error", value: "user-already-exists" };
+ *     }
+ *
+ *    if (await userWithHandleExists(tx, request.handle)) {
+ *       return { status: "error", value: "duplicate-handle" };
+ *     }
+ *
+ *     await insertUser(tx, request);
+ *     return { status: "success", value: { id: request.id } };
+ *   });
+ * };
+ *
+ * // Usage when consuming the function
+ * const result = await registerNewUser(...)
+ *
+ * if (result.status === "success") {
+ *   console.log(result.value.id) // Logs some user id
+ * } else {
+ *   console.log(result.value) // Logs either "user-already-exists" or "duplicate-handle"
+ * }
+ * ```
+ */
 export type Result<Success, Error> =
   | { status: "success"; value: Success }
   | { status: "error"; value: Error };

--- a/validation.ts
+++ b/validation.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import { Request, Response, RequestHandler } from "express";
 import { AnyZodObject, z } from "zod";
 
 /**
@@ -27,7 +27,7 @@ export const withValidatedRequest = async <Schema extends AnyZodObject>(
   req: Request,
   res: Response,
   schema: Schema,
-  fn: (data: z.infer<Schema>) => Promise<void>
+  fn: (data: z.infer<Schema>) => Promise<any>
 ) => {
   try {
     const data = await schema.passthrough().parseAsync(req);


### PR DESCRIPTION
This PR contains endpoints for retrieving and updating the current user's settings. 

I added a new type to combat the sending response in a transaction, it's called `Result`. This is a common type that exists in many programming languages, but I'll reiterate its purpose here. `Result` is a discriminated union type with 2 generics, one for a success, and one for a failure. If the `status` field of `Result` is equal to `success`, then the type `value` field will be equal to the Success generic type, and if `status` is `"error"` then you know what type `value` is in that case as well.

It can be used like this:

```ts
const func = (): Result<"good", "big-chungus-broke-it"> => {
  if (somethingReallyBadHappened) {
    return { status: "error", value: "big-chungus-broke-it" } 
  }
  return { status: "success", value: "good" }
}

const result = func()
if (result.status === "error") {
  console.log(result.value) // Logs "big-chungus-broke-id"
} else {
  console.log(result.value) // Logs "good"
}
```

The reason for adding this type, is so that we can safely return errors from transactions in a way that makes them easy to translate into HTTP status codes. If a function from planetscale or whatever throws an error, I would prefer for that to be translated into a 500. We should try to check for appropriate error conditions beforehand, because it makes the flow clear and prevents having to parse a weirdly formatted mysql error in a `catch` block.

Additionally, for endpoints which update an entity that can contain an optional fields in the body (eg. updating settings), feel free to just query all the current values from the DB and merge them with the request body values. This prevents the weird building sql in a loop even if it means an extra query.