### PR TITLE
Typesaferouter

### DIFF
--- a/APILambda/events/getEventsByRegion.ts
+++ b/APILambda/events/getEventsByRegion.ts
@@ -12,14 +12,15 @@ export const getEventsByRegionRouter = (environment: ServerEnvironment, router: 
    * Get events by region
    */
   router.get("/", {}, async (req, res) => {
-    await environment.conn.transaction(async (tx) => {
-      const result = await getEvents(tx, {
+    const result = await environment.conn.transaction(async (tx) => {
+      return await getEvents(tx, {
         userId: res.locals.selfId,
         longitude: req.query.longitude as unknown as number,
         latitude: req.query.latitude as unknown as number,
         radiusMeters: req.query.radiusMeters as unknown as number
       })
-      return res.status(200).json({ result })
     })
+
+    return res.status(200).json({ result })
   })
 }

--- a/APILambda/shared/Responses.ts
+++ b/APILambda/shared/Responses.ts
@@ -18,5 +18,5 @@ export const userNotFoundBody = (userId: string) => ({
    * @param userId the id of the user who was not found.
    */
 export const userNotFoundResponse = (res: Response, userId: string) => {
-  res.status(404).json(userNotFoundBody(userId))
+  return res.status(404).json(userNotFoundBody(userId))
 }

--- a/APILambda/user/updateUserProfile.ts
+++ b/APILambda/user/updateUserProfile.ts
@@ -1,6 +1,7 @@
-import { ServerEnvironment } from "../env"
-import { ValidatedRouter } from "../validation"
-import { updateUserProfile } from "./SQL"
+import { z } from "zod"
+import { ServerEnvironment } from "../env.js"
+import { ValidatedRouter } from "../validation.js"
+import { updateUserProfile } from "./SQL.js"
 
 /**
  * Creates routes related to user operations.
@@ -12,14 +13,15 @@ export const updateUserProfileRouter = (environment: ServerEnvironment, router: 
   /**
    * updates the current user's profile
    */
-  router.patch("/self", {}, async (req, res) => {
-    await environment.conn.transaction(async (tx) => {
-      const result = await updateUserProfile(tx, {
+  router.patch("/self", { bodySchema: z.object({ handle: z.string() }) }, async (req, res) => {
+    const result = await environment.conn.transaction(async (tx) => {
+      return await updateUserProfile(tx, {
         selfId: res.locals.selfId,
         ...req.body
       })
-      return res.status(200).json({ result })
     })
+
+    return res.status(200).json({ result })
   })
 
   return router

--- a/APILambda/validation.ts
+++ b/APILambda/validation.ts
@@ -41,9 +41,9 @@ export const validateRequest = ({ bodySchema, querySchema, pathParamsSchema }: V
   async (req: Request, res: Response, next: NextFunction) => {
     try {
       const validationSchema = z.object({
-        body: bodySchema ?? z.object({}).nonstrict(),
-        query: querySchema ?? z.object({}).nonstrict(),
-        params: pathParamsSchema ?? z.object({}).nonstrict()
+        body: bodySchema ?? z.object({}).strict(),
+        query: querySchema ?? z.object({}).strict(),
+        params: pathParamsSchema ?? z.object({}).strict()
       })
 
       await validationSchema.parseAsync({

--- a/APILambda/validation.ts
+++ b/APILambda/validation.ts
@@ -46,11 +46,15 @@ export const validateRequest = ({ bodySchema, querySchema, pathParamsSchema }: V
         params: pathParamsSchema ?? z.object({}).strict()
       })
 
-      await validationSchema.parseAsync({
+      const { body, query, params } = await validationSchema.parseAsync({
         body: req.body,
         query: req.query,
         params: req.params
       })
+
+      req.body = body
+      req.query = query
+      req.params = params
 
       next()
     } catch (error) {

--- a/APILambda/validation.ts
+++ b/APILambda/validation.ts
@@ -67,7 +67,7 @@ export const validateRequest = ({ bodySchema, querySchema, pathParamsSchema }: V
 type InferRequestSchemaType<T> = T extends ZodSchema<any> ? z.infer<T> : never;
 
 type ValidatedRequestHandler<S extends ValidationSchemas> = (
-  req: Request & {
+  req: Omit<Request, "body" | "query" | "params"> & {
     body: InferRequestSchemaType<S["bodySchema"]>;
     query: InferRequestSchemaType<S["querySchema"]>;
     params: InferRequestSchemaType<S["pathParamsSchema"]>;
@@ -119,27 +119,27 @@ export class ValidatedRouter {
   }
 
   get<Schema extends ValidationSchemas> (path: string, schema: Pick<Schema, "querySchema" | "pathParamsSchema">, ...handlers: ValidatedRequestHandler<Schema>[]): this {
-    this.router.get(path, validateRequest(schema), ...handlers)
+    this.router.get(path, validateRequest(schema), ...handlers as any)
     return this
   }
 
   delete<Schema extends ValidationSchemas> (path: string, schema: Schema, ...handlers: ValidatedRequestHandler<Schema>[]): this {
-    this.router.delete(path, validateRequest(schema), ...handlers)
+    this.router.delete(path, validateRequest(schema), ...handlers as any)
     return this
   }
 
   patch<Schema extends ValidationSchemas> (path: string, schema: Schema, ...handlers: ValidatedRequestHandler<Schema>[]): this {
-    this.router.patch(path, validateRequest(schema), ...handlers)
+    this.router.patch(path, validateRequest(schema), ...handlers as any)
     return this
   }
 
   put<Schema extends ValidationSchemas> (path: string, schema: Schema, ...handlers: ValidatedRequestHandler<Schema>[]): this {
-    this.router.put(path, validateRequest(schema), ...handlers)
+    this.router.put(path, validateRequest(schema), ...handlers as any)
     return this
   }
 
   post<Schema extends ValidationSchemas> (path: string, schema: Schema, ...handlers: ValidatedRequestHandler<Schema>[]): this {
-    this.router.post(path, validateRequest(schema), ...handlers)
+    this.router.post(path, validateRequest(schema), ...handlers as any)
     return this
   }
 


### PR DESCRIPTION
Modified the type signatures of the ValidatedRouter methods in order to make the methods typesafe while keeping the implementation the same. This allows us to use multiple handlers similar to the standard express router methods with added typesafety, at the cost of a little extra ts boilerplate.