### PR TITLE
Add lastUpdatedAt to user settings

### DIFF
--- a/APILambda/user/settings/getUserSettings.test.ts
+++ b/APILambda/user/settings/getUserSettings.test.ts
@@ -1,13 +1,11 @@
 import { resetDatabaseBeforeEach } from "../../test/database.js"
-import { callGetSettings, createUserAndUpdateAuth } from "../../test/helpers/users.js"
+import {
+  callGetSettings,
+  createUserAndUpdateAuth
+} from "../../test/helpers/users.js"
 
 describe("Get Settings tests", () => {
   resetDatabaseBeforeEach()
-
-  // it("should return 500 when we can't retrieve a user's profile", async () => {
-  //   const resp = await callGetSettings(global.unregisteredUser.auth)
-  //   expect(resp.status).toEqual(500)
-  // })
 
   it("should return 401 when the user has no profile", async () => {
     const resp = await callGetSettings(global.defaultUser.auth)
@@ -24,7 +22,8 @@ describe("Get Settings tests", () => {
       isEventNotificationsEnabled: true,
       isMentionsNotificationsEnabled: true,
       isChatNotificationsEnabled: true,
-      isFriendRequestNotificationsEnabled: true
+      isFriendRequestNotificationsEnabled: true,
+      lastUpdatedAt: undefined
     })
     expect(resp.status).toEqual(200)
   })

--- a/APILambda/user/settings/getUserSettings.ts
+++ b/APILambda/user/settings/getUserSettings.ts
@@ -14,8 +14,8 @@ import { DEFAULT_USER_SETTINGS } from "./updateUserSettings.js"
  * @returns a result that indicates that the user is not found, or their current settings
  */
 export const queryUserSettings = (conn: SQLExecutable, userId: string) =>
-  userWithIdExists(conn, userId)
-    .flatMapSuccess(() => conn.queryFirstResult<UserSettings>(
+  userWithIdExists(conn, userId).flatMapSuccess(() =>
+    conn.queryFirstResult<UserSettings>(
       `
     SELECT 
       isAnalyticsEnabled, 
@@ -28,7 +28,8 @@ export const queryUserSettings = (conn: SQLExecutable, userId: string) =>
     WHERE userId = :userId
   `,
       { userId }
-    ))
+    )
+  )
 
 export const getUserSettingsRouter = (
   environment: ServerEnvironment,
@@ -40,7 +41,7 @@ export const getUserSettingsRouter = (
   router.getWithValidation("/self/settings", {}, (_, res) =>
     queryUserSettings(conn, res.locals.selfId)
       .flatMapFailure(() => success(DEFAULT_USER_SETTINGS))
-      .mapFailure((error) => { console.log("error is ,", error); return res.status(500).json({ error }) })
-      .mapSuccess(settings => res.status(200).json(settings).send())
+      .mapFailure((error) => res.status(500).json({ error }))
+      .mapSuccess((settings) => res.status(200).json(settings).send())
   )
 }

--- a/APILambda/user/settings/getUserSettings.ts
+++ b/APILambda/user/settings/getUserSettings.ts
@@ -2,7 +2,7 @@ import { SQLExecutable, conn, success } from "TiFBackendUtils"
 import { ServerEnvironment } from "../../env.js"
 import { ValidatedRouter } from "../../validation.js"
 import { userWithIdExists } from "../SQL.js"
-import { UserSettings } from "./models.js"
+import { DatabaseUserSettings } from "./models.js"
 import { DEFAULT_USER_SETTINGS } from "./updateUserSettings.js"
 
 /**
@@ -15,7 +15,7 @@ import { DEFAULT_USER_SETTINGS } from "./updateUserSettings.js"
  */
 export const queryUserSettings = (conn: SQLExecutable, userId: string) =>
   userWithIdExists(conn, userId).flatMapSuccess(() =>
-    conn.queryFirstResult<UserSettings>(
+    conn.queryFirstResult<DatabaseUserSettings>(
       `
     SELECT 
       isAnalyticsEnabled, 
@@ -23,7 +23,8 @@ export const queryUserSettings = (conn: SQLExecutable, userId: string) =>
       isEventNotificationsEnabled, 
       isMentionsNotificationsEnabled, 
       isChatNotificationsEnabled, 
-      isFriendRequestNotificationsEnabled
+      isFriendRequestNotificationsEnabled,
+      lastUpdatedAt
     FROM userSettings
     WHERE userId = :userId
   `,

--- a/APILambda/user/settings/models.ts
+++ b/APILambda/user/settings/models.ts
@@ -16,3 +16,5 @@ export const UserSettingsSchema = z.object({
  * A type representing a user's settings.
  */
 export type UserSettings = z.infer<typeof UserSettingsSchema>
+
+export type DatabaseUserSettings = UserSettings & { lastUpdatedAt: Date }

--- a/APILambda/user/settings/updateUserSettings.ts
+++ b/APILambda/user/settings/updateUserSettings.ts
@@ -32,22 +32,27 @@ const overwriteUserSettings = (
 ) =>
   conn.transaction((tx) =>
     queryUserSettings(tx, userId)
-      .flatMapSuccess(currentSettings => updateUserSettings(tx, userId, {
-        ...currentSettings,
-        ...settings
-      }))
-      .flatMapFailure(() => insertUserSettings(tx, userId, {
-        ...DEFAULT_USER_SETTINGS,
-        ...settings
-      }))
+      .flatMapSuccess((currentSettings) =>
+        updateUserSettings(tx, userId, {
+          ...currentSettings,
+          ...settings
+        })
+      )
+      .flatMapFailure(() =>
+        insertUserSettings(tx, userId, {
+          ...DEFAULT_USER_SETTINGS,
+          ...settings
+        })
+      )
   )
 
 const updateUserSettings = (
   conn: SQLExecutable,
   userId: string,
   settings: UserSettings
-) => conn.queryResults<UserSettings>(
-  `
+) =>
+  conn.queryResults(
+    `
     UPDATE userSettings 
     SET 
       isAnalyticsEnabled = :isAnalyticsEnabled,
@@ -55,19 +60,21 @@ const updateUserSettings = (
       isEventNotificationsEnabled = :isEventNotificationsEnabled,
       isMentionsNotificationsEnabled = :isMentionsNotificationsEnabled,
       isChatNotificationsEnabled = :isChatNotificationsEnabled,
-      isFriendRequestNotificationsEnabled = :isFriendRequestNotificationsEnabled
+      isFriendRequestNotificationsEnabled = :isFriendRequestNotificationsEnabled,
+      lastUpdatedAt = NOW()
     WHERE 
       userId = :userId 
   `,
-  { userId, ...settings }
-)
+    { userId, ...settings }
+  )
 
 const insertUserSettings = (
   conn: SQLExecutable,
   userId: string,
   settings: UserSettings
-) => conn.queryResults<UserSettings>(
-  `
+) =>
+  conn.queryResults(
+    `
     INSERT INTO userSettings (
       userId, 
       isAnalyticsEnabled, 
@@ -86,8 +93,8 @@ const insertUserSettings = (
       :isFriendRequestNotificationsEnabled
     )
   `,
-  { userId, ...settings }
-)
+    { userId, ...settings }
+  )
 
 /**
  * Creates routes related to user operations.


### PR DESCRIPTION
Adds a `lastUpdatedAt` field to the user settings which is needed to perform settings sync on the client.