### PR TITLE
Block user endpoint

### DIFF
--- a/APILambda/app.ts
+++ b/APILambda/app.ts
@@ -65,7 +65,7 @@ const addUserRoutes = (environment: ServerEnvironment) => {
   getUserSettingsRouter(environment, router)
   getSelfRouter(environment, router)
   getUserRouter(environment, router)
-  sendFriendRequestsRouter(environment, router)
+  sendFriendRequestsRouter(router)
   updateUserSettingsRouter(environment, router)
   updateUserProfileRouter(environment, router)
   createBlockUserRouter(router)

--- a/APILambda/app.ts
+++ b/APILambda/app.ts
@@ -14,6 +14,7 @@ import { getUserSettingsRouter } from "./user/settings/getUserSettings.js"
 import { updateUserSettingsRouter } from "./user/settings/updateUserSettings.js"
 import { updateUserProfileRouter } from "./user/updateUserProfile.js"
 import { createValidatedRouter } from "./validation.js"
+import { createBlockUserRouter } from "./user/blockUser.js"
 
 /**
  * Creates an application instance.
@@ -36,7 +37,12 @@ export const addBenchmarking = (app: Application) => {
       const duration = Date.now() - start
       const endMem = process.memoryUsage().heapUsed
       const diffMem = endMem - startMem
-      console.table([{ duration: `[${req.method}] ${req.originalUrl} took ${duration}ms`, memoryUsage: `${diffMem} bytes` }])
+      console.table([
+        {
+          duration: `[${req.method}] ${req.originalUrl} took ${duration}ms`,
+          memoryUsage: `${diffMem} bytes`
+        }
+      ])
     })
     next()
   })
@@ -62,6 +68,7 @@ const addUserRoutes = (environment: ServerEnvironment) => {
   sendFriendRequestsRouter(environment, router)
   updateUserSettingsRouter(environment, router)
   updateUserProfileRouter(environment, router)
+  createBlockUserRouter(router)
   return router
 }
 

--- a/APILambda/test/helpers/users.ts
+++ b/APILambda/test/helpers/users.ts
@@ -48,10 +48,14 @@ export const callPostUser = async (bearerToken?: string) => {
 }
 
 // database is reset for each test so we need to create a new auth for each test
-export const createUserAndUpdateAuth = async (bearerToken: string): Promise<string> => {
+export const createUserAndUpdateAuth = async (
+  bearerToken: string
+): Promise<string> => {
   await callPostUser(bearerToken)
 
-  const claims = JSON.parse(Buffer.from(bearerToken.split(".")[1], "base64").toString())
+  const claims = JSON.parse(
+    Buffer.from(bearerToken.split(".")[1], "base64").toString()
+  )
   claims.profile_created = true
 
   const token = jwt.sign(claims, "supersecret", { algorithm: "HS256" })
@@ -73,7 +77,12 @@ export const callDeleteSelf = async (bearerToken: string) => {
     .send()
 }
 
-export const callAutocompleteUsers = async (auth: string, handle: string, limit: number) => { // todo: remove required auth
+export const callAutocompleteUsers = async (
+  auth: string,
+  handle: string,
+  limit: number
+) => {
+  // todo: remove required auth
   return await request(testApp)
     .get("/user/autocomplete")
     .query({ handle, limit })
@@ -89,4 +98,14 @@ export const callUpdateUserHandle = async (
     .patch("/user/self")
     .set("Authorization", userId)
     .send({ handle: userHandle })
+}
+
+export const callBlockUser = async (
+  userToken: string,
+  blockedUserId: string
+) => {
+  return await request(testApp)
+    .patch(`/user/block/${blockedUserId}`)
+    .set("Authorization", userToken)
+    .send()
 }

--- a/APILambda/user/SQL.ts
+++ b/APILambda/user/SQL.ts
@@ -1,8 +1,5 @@
-import { SQLExecutable, success } from "TiFBackendUtils"
-import {
-  DatabaseUser,
-  UserToProfileRelationStatus
-} from "./models.js"
+import { SQLExecutable } from "TiFBackendUtils"
+import { DatabaseUser } from "./models.js"
 
 export type RegisterUserRequest = {
   id: string
@@ -10,88 +7,10 @@ export type RegisterUserRequest = {
   handle: string
 }
 
-/**
- * Sends a friend request to the user represented by `receiverId`. If the 2 users have no
- * prior relationship, then a `friend-request-pending` status will be returned, otherwise
- * a `friends` status will be returned if the receiver has sent a friend request to the sender.
- *
- * @param conn the query executor to use
- * @param senderId the id of the user who is sending the friend request
- * @param receiverId the id of the user who is receiving the friend request
- */
-export const sendFriendRequest = (
+export const userWithHandleDoesNotExist = (
   conn: SQLExecutable,
-  senderId: string,
-  receiverId: string
+  handle: string
 ) =>
-  twoWayUserRelation(
-    conn,
-    senderId,
-    receiverId
-  ).flatMapSuccess(({ youToThemStatus, themToYouStatus }) => {
-    if (
-      youToThemStatus === "friends" ||
-      youToThemStatus === "friend-request-pending"
-    ) {
-      return success({ statusChanged: false, status: youToThemStatus })
-    }
-
-    if (themToYouStatus === "friend-request-pending") {
-      return makeFriends(conn, senderId, receiverId).withSuccess({ statusChanged: true, status: "friends" })
-    }
-
-    return addPendingFriendRequest(conn, senderId, receiverId).withSuccess({ statusChanged: true, status: "friend-request-pending" })
-  })
-
-const twoWayUserRelation = (
-  conn: SQLExecutable,
-  youId: string,
-  themId: string
-) => conn.queryResults<{
-    fromUserId: string
-    toUserId: string
-    status: UserToProfileRelationStatus
-  }>(
-    `
-    SELECT * FROM userRelations ur 
-    WHERE 
-      (ur.fromUserId = :youId AND ur.toUserId = :themId) 
-      OR 
-      (ur.fromUserId = :themId AND ur.toUserId = :youId) 
-    `,
-    { youId, themId }
-  ).flatMapSuccess(results => success({
-    youToThemStatus: results.find(
-      (res) => res.fromUserId === youId && res.toUserId === themId
-    )?.status,
-    themToYouStatus: results.find(
-      (res) => res.fromUserId === themId && res.toUserId === youId
-    )?.status
-  }))
-
-const makeFriends = (
-  conn: SQLExecutable,
-  fromUserId: string,
-  toUserId: string
-) => conn.queryResults(
-  `
-    UPDATE userRelations 
-    SET status = 'friends' 
-    WHERE (fromUserId = :fromUserId AND toUserId = :toUserId) OR (fromUserId = :toUserId AND toUserId = :fromUserId)
-  `,
-  { fromUserId, toUserId }
-)
-
-const addPendingFriendRequest = (
-  conn: SQLExecutable,
-  senderId: string,
-  receiverId: string
-) => conn.queryResults(
-  "INSERT INTO userRelations (fromUserId, toUserId, status) VALUES (:senderId, :receiverId, 'friend-request-pending')",
-  { senderId, receiverId }
-)
-
-export const userWithHandleDoesNotExist = (conn: SQLExecutable, handle: string) =>
   conn
     .queryHasResults("SELECT TRUE FROM user WHERE handle = :handle", {
       handle
@@ -99,16 +18,15 @@ export const userWithHandleDoesNotExist = (conn: SQLExecutable, handle: string) 
     .inverted()
     .withFailure("duplicate-handle" as const)
 
-export const userWithIdExists = (conn: SQLExecutable, id: string) => conn.queryHasResults("SELECT TRUE FROM user WHERE id = :id", { id })
+export const userWithIdExists = (conn: SQLExecutable, id: string) =>
+  conn.queryHasResults("SELECT TRUE FROM user WHERE id = :id", { id })
 
 /**
  * Queries the user with the given id.
  */
 export const userWithId = (conn: SQLExecutable, userId: string) =>
-  conn.queryFirstResult<DatabaseUser>(
-    "SELECT * FROM user WHERE id = :userId",
-    {
+  conn
+    .queryFirstResult<DatabaseUser>("SELECT * FROM user WHERE id = :userId", {
       userId
-    }
-  )
+    })
     .withFailure("user-not-found" as const)

--- a/APILambda/user/blockUser.test.ts
+++ b/APILambda/user/blockUser.test.ts
@@ -1,0 +1,15 @@
+import { randomUUID } from "crypto"
+import {
+  callBlockUser,
+  createUserAndUpdateAuth
+} from "../test/helpers/users.js"
+
+describe("Block User tests", () => {
+  it("should 404 when trying to block a non-existent user", async () => {
+    const userId = randomUUID()
+    const token1 = await createUserAndUpdateAuth(global.defaultUser.auth)
+    const resp = await callBlockUser(token1, userId)
+    expect(resp.status).toEqual(404)
+    expect(resp.body).toMatchObject({ error: "user-not-found", userId })
+  })
+})

--- a/APILambda/user/blockUser.test.ts
+++ b/APILambda/user/blockUser.test.ts
@@ -41,4 +41,21 @@ describe("Block User tests", () => {
       })
     )
   })
+
+  it("should not remove the relation status of blocked user when you are blocked by them", async () => {
+    const token1 = await createUserAndUpdateAuth(global.defaultUser.auth)
+    const token2 = await createUserAndUpdateAuth(global.defaultUser2.auth)
+    await callBlockUser(token1, global.defaultUser2.id)
+    await callBlockUser(token2, global.defaultUser.id)
+
+    const resp = await callGetUser(token2, global.defaultUser.id)
+    expect(resp.body).toMatchObject(
+      expect.objectContaining({
+        relations: {
+          youToThem: "blocked",
+          themToYou: "blocked"
+        }
+      })
+    )
+  })
 })

--- a/APILambda/user/blockUser.test.ts
+++ b/APILambda/user/blockUser.test.ts
@@ -1,10 +1,15 @@
 import { randomUUID } from "crypto"
 import {
   callBlockUser,
+  callGetUser,
+  callPostFriendRequest,
   createUserAndUpdateAuth
 } from "../test/helpers/users.js"
+import { resetDatabaseBeforeEach } from "../test/database.js"
 
 describe("Block User tests", () => {
+  resetDatabaseBeforeEach()
+
   it("should 404 when trying to block a non-existent user", async () => {
     const userId = randomUUID()
     const token1 = await createUserAndUpdateAuth(global.defaultUser.auth)
@@ -18,5 +23,22 @@ describe("Block User tests", () => {
     await createUserAndUpdateAuth(global.defaultUser2.auth)
     const resp = await callBlockUser(token1, global.defaultUser2.id)
     expect(resp.status).toEqual(204)
+  })
+
+  it("should remove relation status of blocked user to you when blocking", async () => {
+    const token1 = await createUserAndUpdateAuth(global.defaultUser.auth)
+    const token2 = await createUserAndUpdateAuth(global.defaultUser2.auth)
+    await callPostFriendRequest(token2, global.defaultUser.id)
+    await callBlockUser(token1, global.defaultUser2.id)
+
+    const resp = await callGetUser(token1, global.defaultUser2.id)
+    expect(resp.body).toMatchObject(
+      expect.objectContaining({
+        relations: {
+          youToThem: "blocked",
+          themToYou: "not-friends"
+        }
+      })
+    )
   })
 })

--- a/APILambda/user/blockUser.test.ts
+++ b/APILambda/user/blockUser.test.ts
@@ -12,4 +12,11 @@ describe("Block User tests", () => {
     expect(resp.status).toEqual(404)
     expect(resp.body).toMatchObject({ error: "user-not-found", userId })
   })
+
+  it("should 204 when successful block", async () => {
+    const token1 = await createUserAndUpdateAuth(global.defaultUser.auth)
+    await createUserAndUpdateAuth(global.defaultUser2.auth)
+    const resp = await callBlockUser(token1, global.defaultUser2.id)
+    expect(resp.status).toEqual(204)
+  })
 })

--- a/APILambda/user/blockUser.ts
+++ b/APILambda/user/blockUser.ts
@@ -34,7 +34,19 @@ const blockUser = (
       return conn.queryResults(
         `
       INSERT INTO userRelations (fromUserId, toUserId, status)
-      VALUES (:fromUserId, :toUserId, "blocked")
+      VALUES (:fromUserId, :toUserId, 'blocked')
+      ON DUPLICATE KEY UPDATE
+        status = 'blocked'
+      `,
+        { fromUserId, toUserId }
+      )
+    })
+    .flatMapSuccess(() => {
+      return conn.queryResults(
+        `
+      UPDATE userRelations
+      SET status = 'not-friends'
+      WHERE fromUserId = :toUserId AND toUserId = :fromUserId;
       `,
         { fromUserId, toUserId }
       )

--- a/APILambda/user/blockUser.ts
+++ b/APILambda/user/blockUser.ts
@@ -46,7 +46,7 @@ const blockUser = (
         `
       UPDATE userRelations
       SET status = 'not-friends'
-      WHERE fromUserId = :toUserId AND toUserId = :fromUserId;
+      WHERE fromUserId = :toUserId AND toUserId = :fromUserId AND status != 'blocked';
       `,
         { fromUserId, toUserId }
       )

--- a/APILambda/user/blockUser.ts
+++ b/APILambda/user/blockUser.ts
@@ -1,8 +1,21 @@
+import { conn } from "TiFBackendUtils"
 import { userNotFoundResponse } from "../shared/Responses.js"
 import { ValidatedRouter } from "../validation.js"
+import { userWithIdExists } from "./SQL.js"
+import { z } from "zod"
+
+const BlockUserRequestSchema = z.object({
+  userId: z.string().uuid()
+})
 
 export const createBlockUserRouter = (router: ValidatedRouter) => {
-  router.patch("/block/:userId", async (req, res) => {
-    return userNotFoundResponse(res, req.params.userId)
-  })
+  router.patchWithValidation(
+    "/block/:userId",
+    { pathParamsSchema: BlockUserRequestSchema },
+    async (req, res) => {
+      return userWithIdExists(conn, req.params.userId)
+        .mapSuccess(() => res.status(204).send())
+        .mapFailure(() => userNotFoundResponse(res, req.params.userId))
+    }
+  )
 }

--- a/APILambda/user/blockUser.ts
+++ b/APILambda/user/blockUser.ts
@@ -1,4 +1,4 @@
-import { conn } from "TiFBackendUtils"
+import { SQLExecutable, conn } from "TiFBackendUtils"
 import { userNotFoundResponse } from "../shared/Responses.js"
 import { ValidatedRouter } from "../validation.js"
 import { userWithIdExists } from "./SQL.js"
@@ -13,9 +13,30 @@ export const createBlockUserRouter = (router: ValidatedRouter) => {
     "/block/:userId",
     { pathParamsSchema: BlockUserRequestSchema },
     async (req, res) => {
-      return userWithIdExists(conn, req.params.userId)
+      return conn
+        .transaction((tx) => {
+          return blockUser(tx, res.locals.selfId, req.params.userId)
+        })
         .mapSuccess(() => res.status(204).send())
         .mapFailure(() => userNotFoundResponse(res, req.params.userId))
     }
   )
+}
+
+const blockUser = (
+  conn: SQLExecutable,
+  fromUserId: string,
+  toUserId: string
+) => {
+  return userWithIdExists(conn, toUserId)
+    .withFailure("user-not-found" as const)
+    .flatMapSuccess(() => {
+      return conn.queryResults(
+        `
+      INSERT INTO userRelations (fromUserId, toUserId, status)
+      VALUES (:fromUserId, :toUserId, "blocked")
+      `,
+        { fromUserId, toUserId }
+      )
+    })
 }

--- a/APILambda/user/blockUser.ts
+++ b/APILambda/user/blockUser.ts
@@ -1,0 +1,8 @@
+import { userNotFoundResponse } from "../shared/Responses.js"
+import { ValidatedRouter } from "../validation.js"
+
+export const createBlockUserRouter = (router: ValidatedRouter) => {
+  router.patch("/block/:userId", async (req, res) => {
+    return userNotFoundResponse(res, req.params.userId)
+  })
+}

--- a/APILambda/user/getUser.test.ts
+++ b/APILambda/user/getUser.test.ts
@@ -1,6 +1,10 @@
 import { randomUUID } from "crypto"
 import { resetDatabaseBeforeEach } from "../test/database.js"
-import { callGetSelf, callGetUser, createUserAndUpdateAuth } from "../test/helpers/users.js"
+import {
+  callGetSelf,
+  callGetUser,
+  createUserAndUpdateAuth
+} from "../test/helpers/users.js"
 
 describe("GetUser tests", () => {
   resetDatabaseBeforeEach()
@@ -19,7 +23,7 @@ describe("GetUser tests", () => {
     const user2 = await global.registerUser({ name: "John Doe" })
     const user2Token = await createUserAndUpdateAuth(user2.auth)
     const user2Profile = (await callGetSelf(user2Token)).body
-    const resp = await callGetUser(user1Token, user2Profile.id)
+    const resp = await callGetUser(user1Token, user2.id)
 
     expect(resp.status).toEqual(200)
     expect(resp.body).toMatchObject(

--- a/APILambda/user/getUser.ts
+++ b/APILambda/user/getUser.ts
@@ -38,6 +38,7 @@ type DatabaseUserWithRelation = DatabaseUser & {
 }
 
 const toUserWithRelationResponse = (user: DatabaseUserWithRelation) => ({
+  id: user.id,
   bio: user.bio,
   creationDate: user.creationDate,
   handle: user.handle,

--- a/APILambda/user/getUser.ts
+++ b/APILambda/user/getUser.ts
@@ -1,8 +1,8 @@
-import { conn } from "TiFBackendUtils"
+import { SQLExecutable, conn } from "TiFBackendUtils"
 import { z } from "zod"
 import { ServerEnvironment } from "../env.js"
 import { ValidatedRouter } from "../validation.js"
-import { userWithId } from "./SQL.js"
+import { DatabaseUser, UserToProfileRelationStatus } from "./models.js"
 
 const userIdSchema = z.object({
   userId: z.string()
@@ -24,8 +24,51 @@ export const getUserRouter = (
     "/:userId",
     { pathParamsSchema: userIdSchema },
     (req, res) =>
-      userWithId(conn, req.params.userId)
+      userAndRelationsWithId(conn, req.params.userId, res.locals.selfId)
+        .mapSuccess((dbUser) => {
+          return res.status(200).json(toUserWithRelationResponse(dbUser))
+        })
         .mapFailure((error) => res.status(404).json({ error }))
-        .mapSuccess((user) => res.status(200).json({ ...user, relation: "not-friends" }))
+  )
+}
+
+type DatabaseUserWithRelation = DatabaseUser & {
+  themToYouStatus: UserToProfileRelationStatus | null
+  youToThemStatus: UserToProfileRelationStatus | null
+}
+
+const toUserWithRelationResponse = (user: DatabaseUserWithRelation) => ({
+  bio: user.bio,
+  creationDate: user.creationDate,
+  handle: user.handle,
+  name: user.name,
+  profileImageURL: user.profileImageURL,
+  updatedAt: user.updatedAt,
+  relations: {
+    themToYou: user.themToYouStatus,
+    youToThem: user.youToThemStatus
+  }
+})
+
+const userAndRelationsWithId = (
+  conn: SQLExecutable,
+  userId: string,
+  fromUserId: string
+) => {
+  return conn.queryFirstResult<DatabaseUserWithRelation>(
+    `
+    SELECT *, 
+    ur1.status AS themToYouStatus, 
+    ur2.status AS youToThemStatus 
+    FROM user u 
+    LEFT JOIN userRelations ur1 ON ur1.fromUserId = u.id
+    AND ur1.fromUserId = :userId
+    AND ur1.toUserId = :fromUserId
+    LEFT JOIN userRelations ur2 ON ur2.toUserId = u.id
+    AND ur2.fromUserId = :fromUserId
+    AND ur2.toUserId = :userId
+    WHERE u.id = :userId;
+  `,
+    { userId, fromUserId }
   )
 }

--- a/APILambda/user/sendFriendRequest.test.ts
+++ b/APILambda/user/sendFriendRequest.test.ts
@@ -8,7 +8,7 @@ import {
 describe("FriendRequest tests", () => {
   resetDatabaseBeforeEach()
 
-  it("should have a pending status when no prior relation between uses", async () => {
+  it("should have a pending status when no prior relation between users", async () => {
     const token1 = await createUserAndUpdateAuth(global.defaultUser.auth)
     const resp = await callPostFriendRequest(token1, global.defaultUser2.id)
     expect(resp.status).toEqual(201)

--- a/APILambda/user/sendFriendRequest.test.ts
+++ b/APILambda/user/sendFriendRequest.test.ts
@@ -53,4 +53,14 @@ describe("FriendRequest tests", () => {
     expect(resp.status).toEqual(403)
     expect(resp.body).toMatchObject({ status: "blocked" })
   })
+
+  it("should unblock the user when trying to send friend request to blocked user", async () => {
+    const token1 = await createUserAndUpdateAuth(global.defaultUser.auth)
+    await createUserAndUpdateAuth(global.defaultUser2.auth)
+    await callBlockUser(token1, global.defaultUser2.id)
+
+    const resp = await callPostFriendRequest(token1, global.defaultUser2.id)
+    expect(resp.status).toEqual(201)
+    expect(resp.body).toMatchObject({ status: "friend-request-pending" })
+  })
 })

--- a/APILambda/user/sendFriendRequest.test.ts
+++ b/APILambda/user/sendFriendRequest.test.ts
@@ -1,29 +1,24 @@
 import { resetDatabaseBeforeEach } from "../test/database.js"
-import { callPostFriendRequest, createUserAndUpdateAuth } from "../test/helpers/users.js"
+import {
+  callBlockUser,
+  callPostFriendRequest,
+  createUserAndUpdateAuth
+} from "../test/helpers/users.js"
 
 describe("FriendRequest tests", () => {
   resetDatabaseBeforeEach()
 
   it("should have a pending status when no prior relation between uses", async () => {
     const token1 = await createUserAndUpdateAuth(global.defaultUser.auth)
-    const resp = await callPostFriendRequest(
-      token1,
-      global.defaultUser2.id
-    )
+    const resp = await callPostFriendRequest(token1, global.defaultUser2.id)
     expect(resp.status).toEqual(201)
     expect(resp.body).toMatchObject({ status: "friend-request-pending" })
   })
 
   it("should return the same status when already existing pending friend request", async () => {
     const token1 = await createUserAndUpdateAuth(global.defaultUser.auth)
-    await callPostFriendRequest(
-      token1,
-      global.defaultUser2.id
-    )
-    const resp = await callPostFriendRequest(
-      token1,
-      global.defaultUser2.id
-    )
+    await callPostFriendRequest(token1, global.defaultUser2.id)
+    const resp = await callPostFriendRequest(token1, global.defaultUser2.id)
     expect(resp.status).toEqual(200)
     expect(resp.body).toMatchObject({ status: "friend-request-pending" })
   })
@@ -31,19 +26,10 @@ describe("FriendRequest tests", () => {
   it("should return the same status when already friends", async () => {
     const token1 = await createUserAndUpdateAuth(global.defaultUser.auth)
     const token2 = await createUserAndUpdateAuth(global.defaultUser2.auth)
-    await callPostFriendRequest(
-      token1,
-      global.defaultUser2.id
-    )
-    await callPostFriendRequest(
-      token2,
-      global.defaultUser.id
-    )
+    await callPostFriendRequest(token1, global.defaultUser2.id)
+    await callPostFriendRequest(token2, global.defaultUser.id)
 
-    const resp = await callPostFriendRequest(
-      token1,
-      global.defaultUser2.id
-    )
+    const resp = await callPostFriendRequest(token1, global.defaultUser2.id)
     expect(resp.status).toEqual(200)
     expect(resp.body).toMatchObject({ status: "friends" })
   })
@@ -51,16 +37,20 @@ describe("FriendRequest tests", () => {
   it("should have a friend status when the receiver sends a friend request to someone who sent them a pending friend request", async () => {
     const token1 = await createUserAndUpdateAuth(global.defaultUser.auth)
     const token2 = await createUserAndUpdateAuth(global.defaultUser2.auth)
-    await callPostFriendRequest(
-      token1,
-      global.defaultUser2.id
-    )
+    await callPostFriendRequest(token1, global.defaultUser2.id)
 
-    const resp = await callPostFriendRequest(
-      token2,
-      global.defaultUser.id
-    )
+    const resp = await callPostFriendRequest(token2, global.defaultUser.id)
     expect(resp.status).toEqual(201)
     expect(resp.body).toMatchObject({ status: "friends" })
+  })
+
+  it("should not allow a user to send friend requests to users who have blocked them", async () => {
+    const token1 = await createUserAndUpdateAuth(global.defaultUser.auth)
+    const token2 = await createUserAndUpdateAuth(global.defaultUser2.auth)
+    await callBlockUser(token1, global.defaultUser2.id)
+
+    const resp = await callPostFriendRequest(token2, global.defaultUser.id)
+    expect(resp.status).toEqual(403)
+    expect(resp.body).toMatchObject({ status: "blocked" })
   })
 })

--- a/APILambda/user/sendFriendRequest.ts
+++ b/APILambda/user/sendFriendRequest.ts
@@ -127,6 +127,11 @@ const addPendingFriendRequest = (
   receiverId: string
 ) =>
   conn.queryResults(
-    "INSERT INTO userRelations (fromUserId, toUserId, status) VALUES (:senderId, :receiverId, 'friend-request-pending')",
+    `
+    INSERT INTO userRelations (fromUserId, toUserId, status) 
+    VALUES (:senderId, :receiverId, 'friend-request-pending')
+    ON DUPLICATE KEY UPDATE
+      status = 'friend-request-pending'
+    `,
     { senderId, receiverId }
   )

--- a/APILambda/user/sendFriendRequest.ts
+++ b/APILambda/user/sendFriendRequest.ts
@@ -1,11 +1,10 @@
-import { conn } from "TiFBackendUtils"
+import { SQLExecutable, conn, failure, success } from "TiFBackendUtils"
 import { z } from "zod"
-import { ServerEnvironment } from "../env.js"
 import { ValidatedRouter } from "../validation.js"
-import { sendFriendRequest } from "./SQL.js"
+import { UserToProfileRelationStatus } from "./models.js"
 
 const friendRequestSchema = z.object({
-  userId: z.string()
+  userId: z.string().uuid()
 })
 
 /**
@@ -13,19 +12,121 @@ const friendRequestSchema = z.object({
  *
  * @param environment see {@link ServerEnvironment}.
  */
-export const sendFriendRequestsRouter = (
-  environment: ServerEnvironment,
-  router: ValidatedRouter
-) => {
+export const sendFriendRequestsRouter = (router: ValidatedRouter) => {
   /**
    * sends a friend request to the specified userId
    */
   router.postWithValidation(
     "/friend/:userId",
     { pathParamsSchema: friendRequestSchema },
-    (req, res) => conn.transaction((tx) => sendFriendRequest(tx, res.locals.selfId, req.params.userId))
-      .mapFailure((error) => res.status(500).json({ error }))
-      .mapSuccess(({ status, statusChanged }) => res.status(statusChanged ? 201 : 200).json({ status }).send())
+    (req, res) =>
+      conn
+        .transaction((tx) =>
+          sendFriendRequest(tx, res.locals.selfId, req.params.userId)
+        )
+        .mapFailure((error) => res.status(403).json({ status: error }))
+        .mapSuccess(({ status, statusChanged }) =>
+          res
+            .status(statusChanged ? 201 : 200)
+            .json({ status })
+            .send()
+        )
   )
   return router
 }
+
+/**
+ * Sends a friend request to the user represented by `receiverId`. If the 2 users have no
+ * prior relationship, then a `friend-request-pending` status will be returned, otherwise
+ * a `friends` status will be returned if the receiver has sent a friend request to the sender.
+ *
+ * @param conn the query executor to use
+ * @param senderId the id of the user who is sending the friend request
+ * @param receiverId the id of the user who is receiving the friend request
+ */
+const sendFriendRequest = (
+  conn: SQLExecutable,
+  senderId: string,
+  receiverId: string
+) =>
+  twoWayUserRelation(conn, senderId, receiverId).flatMapSuccess(
+    ({ youToThemStatus, themToYouStatus }) => {
+      if (
+        youToThemStatus === "friends" ||
+        youToThemStatus === "friend-request-pending"
+      ) {
+        return success({ statusChanged: false, status: youToThemStatus })
+      }
+
+      if (themToYouStatus === "blocked") {
+        return failure("blocked" as const)
+      }
+
+      if (themToYouStatus === "friend-request-pending") {
+        return makeFriends(conn, senderId, receiverId).withSuccess({
+          statusChanged: true,
+          status: "friends" as const
+        })
+      }
+
+      return addPendingFriendRequest(conn, senderId, receiverId).withSuccess({
+        statusChanged: true,
+        status: "friend-request-pending" as const
+      })
+    }
+  )
+
+const twoWayUserRelation = (
+  conn: SQLExecutable,
+  youId: string,
+  themId: string
+) =>
+  conn
+    .queryResults<{
+      fromUserId: string
+      toUserId: string
+      status: UserToProfileRelationStatus
+    }>(
+      `
+    SELECT * FROM userRelations ur 
+    WHERE 
+      (ur.fromUserId = :youId AND ur.toUserId = :themId) 
+      OR 
+      (ur.fromUserId = :themId AND ur.toUserId = :youId) 
+    `,
+      { youId, themId }
+    )
+    .flatMapSuccess((results) =>
+      success({
+        youToThemStatus: results.find(
+          (res) => res.fromUserId === youId && res.toUserId === themId
+        )?.status,
+        themToYouStatus: results.find(
+          (res) => res.fromUserId === themId && res.toUserId === youId
+        )?.status
+      })
+    )
+
+const makeFriends = (
+  conn: SQLExecutable,
+  fromUserId: string,
+  toUserId: string
+) =>
+  conn.queryResults(
+    `
+    UPDATE userRelations 
+    SET status = 'friends' 
+    WHERE (fromUserId = :fromUserId AND toUserId = :toUserId) OR (fromUserId = :toUserId AND toUserId = :fromUserId)
+  `,
+    { fromUserId, toUserId }
+  )
+
+const addPendingFriendRequest = (
+  conn: SQLExecutable,
+  senderId: string,
+  receiverId: string
+) =>
+  conn.queryResults(
+    "INSERT INTO userRelations (fromUserId, toUserId, status) VALUES (:senderId, :receiverId, 'friend-request-pending')",
+    { senderId, receiverId }
+  )

--- a/TiFBackendUtils/UserHandle.ts
+++ b/TiFBackendUtils/UserHandle.ts
@@ -6,14 +6,14 @@ import { ZodUtils } from "./Zod.js"
 export class UserHandle {
   readonly rawValue: string
 
-  private constructor(rawValue: string) {
+  private constructor (rawValue: string) {
     this.rawValue = rawValue
   }
 
   /**
    * Formats this handle by prefixing the string with an "@".
    */
-  toString() {
+  toString () {
     return `@${this.rawValue}`
   }
 
@@ -36,7 +36,7 @@ export class UserHandle {
    * @param rawValue the raw user handle string to validate
    * @returns an {@link UserHandle} instance if successful.
    */
-  static parse(rawValue: string) {
+  static parse (rawValue: string) {
     return UserHandle.REGEX.test(rawValue)
       ? new UserHandle(rawValue)
       : undefined


### PR DESCRIPTION
Adds an enpoint to block a user. Also updates the send friend request endpoint to handle blocked user behavior and updates the query in get user to add the relation status.

This does not handle now neeeded blocked behavior on getUser, getEvent, etc. That will be for a future occurrence of reality.