### PR TITLE
Fix CI Assertion

### DIFF
--- a/APILambda/user/settings/updateUserSettings.test.ts
+++ b/APILambda/user/settings/updateUserSettings.test.ts
@@ -45,7 +45,7 @@ describe("Update Settings tests", () => {
       })
     )
     const settings2LastUpdatedAt = new Date(settings2.lastUpdatedAt)
-    expect(settings2LastUpdatedAt.getTime()).toBeGreaterThan(
+    expect(settings2LastUpdatedAt.getTime()).toBeGreaterThanOrEqual(
       settings1LastUpdatedAt.getTime()
     )
   })


### PR DESCRIPTION
It seems that asserting against the current date in settings would sometimes contain a case where the 2 dates are equal thus causing a test failure. The idea was to assert that the settings were updated at a "later date" from when they were first inserted, but sometimes either through clock drift or other means, the dates would be equal. Due to this, I think its ok to use `toBeGreaterThanOrEqualTo` instead of just `toBeGreaterThan`.