### PR TITLE
Push token registering

### DIFF
--- a/APILambda/app.ts
+++ b/APILambda/app.ts
@@ -16,6 +16,7 @@ import { updateUserProfileRouter } from "./user/updateUserProfile.js"
 import { createValidatedRouter } from "./validation.js"
 import { createBlockUserRouter } from "./user/blockUser.js"
 import { joinEventRouter } from "./events/joinEventById.js"
+import { createRegisterPushTokenRouter } from "./user/registerPushToken.js"
 
 /**
  * Creates an application instance.
@@ -71,6 +72,7 @@ const addUserRoutes = (environment: ServerEnvironment) => {
   updateUserSettingsRouter(environment, router)
   updateUserProfileRouter(environment, router)
   createBlockUserRouter(router)
+  createRegisterPushTokenRouter(router)
   return router
 }
 

--- a/APILambda/test/helpers/users.ts
+++ b/APILambda/test/helpers/users.ts
@@ -2,7 +2,7 @@ import jwt from "jsonwebtoken"
 import request from "supertest"
 import { UserSettings } from "../../user/settings/models.js"
 import { testApp } from "../testApp.js"
-import { PlatformName } from "../../user/registerPushToken.js"
+import { PushTokenPlatformName } from "../../user/registerPushToken.js"
 
 export const callPatchSettings = async (
   bearerToken: string,
@@ -113,7 +113,7 @@ export const callBlockUser = async (
 
 export const callRegisterPushToken = async (
   userToken: string,
-  body: { deviceToken: string; platformName: PlatformName }
+  body: { pushToken: string; platformName: PushTokenPlatformName }
 ) => {
   return await request(testApp)
     .post("/user/notifications/push/register")

--- a/APILambda/test/helpers/users.ts
+++ b/APILambda/test/helpers/users.ts
@@ -109,3 +109,13 @@ export const callBlockUser = async (
     .set("Authorization", userToken)
     .send()
 }
+
+export const callRegisterPushToken = async (
+  userToken: string,
+  deviceToken: string
+) => {
+  return await request(testApp)
+    .post("/user/notifications/push/register")
+    .set("Authorization", userToken)
+    .send({ deviceToken })
+}

--- a/APILambda/test/helpers/users.ts
+++ b/APILambda/test/helpers/users.ts
@@ -2,6 +2,7 @@ import jwt from "jsonwebtoken"
 import request from "supertest"
 import { UserSettings } from "../../user/settings/models.js"
 import { testApp } from "../testApp.js"
+import { PlatformName } from "../../user/registerPushToken.js"
 
 export const callPatchSettings = async (
   bearerToken: string,
@@ -112,10 +113,10 @@ export const callBlockUser = async (
 
 export const callRegisterPushToken = async (
   userToken: string,
-  deviceToken: string
+  body: { deviceToken: string; platformName: PlatformName }
 ) => {
   return await request(testApp)
     .post("/user/notifications/push/register")
     .set("Authorization", userToken)
-    .send({ deviceToken })
+    .send(body)
 }

--- a/APILambda/user/registerPushToken.test.ts
+++ b/APILambda/user/registerPushToken.test.ts
@@ -21,11 +21,11 @@ describe("RegisterPushToken tests", () => {
   it("should 400 when registering an existing push token on the same platform", async () => {
     const user = await global.registerUser({ name: "Bitchell Dickle" })
     const userToken = await createUserAndUpdateAuth(user.auth)
-    const deviceToken = randomUUID()
-    await callRegisterPushToken(userToken, registerPushTokenBody(deviceToken))
+    const pushToken = randomUUID()
+    await callRegisterPushToken(userToken, registerPushTokenBody(pushToken))
     const resp = await callRegisterPushToken(
       userToken,
-      registerPushTokenBody(deviceToken)
+      registerPushTokenBody(pushToken)
     )
     expect(resp.status).toEqual(400)
   })
@@ -41,8 +41,8 @@ describe("RegisterPushToken tests", () => {
     expect(resp.status).toEqual(201)
   })
 
-  const registerPushTokenBody = (deviceToken: string) => ({
-    deviceToken,
+  const registerPushTokenBody = (pushToken: string) => ({
+    pushToken,
     platformName: "android" as const
   })
 })

--- a/APILambda/user/registerPushToken.test.ts
+++ b/APILambda/user/registerPushToken.test.ts
@@ -1,0 +1,26 @@
+import { randomUUID } from "crypto"
+import {
+  callRegisterPushToken,
+  createUserAndUpdateAuth
+} from "../test/helpers/users.js"
+import { resetDatabaseBeforeEach } from "../test/database.js"
+
+describe("RegisterPushToken tests", () => {
+  resetDatabaseBeforeEach()
+
+  it("should 201 when registering a new push token", async () => {
+    const user = await global.registerUser({ name: "Bitchell Dickle" })
+    const userToken = await createUserAndUpdateAuth(user.auth)
+    const resp = await callRegisterPushToken(userToken, randomUUID())
+    expect(resp.status).toEqual(201)
+  })
+
+  it("should 204 when registering an existing push token", async () => {
+    const user = await global.registerUser({ name: "Bitchell Dickle" })
+    const userToken = await createUserAndUpdateAuth(user.auth)
+    const deviceToken = randomUUID()
+    await callRegisterPushToken(userToken, deviceToken)
+    const resp = await callRegisterPushToken(userToken, deviceToken)
+    expect(resp.status).toEqual(204)
+  })
+})

--- a/APILambda/user/registerPushToken.test.ts
+++ b/APILambda/user/registerPushToken.test.ts
@@ -11,16 +11,38 @@ describe("RegisterPushToken tests", () => {
   it("should 201 when registering a new push token", async () => {
     const user = await global.registerUser({ name: "Bitchell Dickle" })
     const userToken = await createUserAndUpdateAuth(user.auth)
-    const resp = await callRegisterPushToken(userToken, randomUUID())
+    const resp = await callRegisterPushToken(
+      userToken,
+      registerPushTokenBody(randomUUID())
+    )
     expect(resp.status).toEqual(201)
   })
 
-  it("should 204 when registering an existing push token", async () => {
+  it("should 400 when registering an existing push token on the same platform", async () => {
     const user = await global.registerUser({ name: "Bitchell Dickle" })
     const userToken = await createUserAndUpdateAuth(user.auth)
     const deviceToken = randomUUID()
-    await callRegisterPushToken(userToken, deviceToken)
-    const resp = await callRegisterPushToken(userToken, deviceToken)
-    expect(resp.status).toEqual(204)
+    await callRegisterPushToken(userToken, registerPushTokenBody(deviceToken))
+    const resp = await callRegisterPushToken(
+      userToken,
+      registerPushTokenBody(deviceToken)
+    )
+    expect(resp.status).toEqual(400)
+  })
+
+  it("should be able to insert multiple tokens with 201s", async () => {
+    const user = await global.registerUser({ name: "Bitchell Dickle" })
+    const userToken = await createUserAndUpdateAuth(user.auth)
+    await callRegisterPushToken(userToken, registerPushTokenBody(randomUUID()))
+    const resp = await callRegisterPushToken(
+      userToken,
+      registerPushTokenBody(randomUUID())
+    )
+    expect(resp.status).toEqual(201)
+  })
+
+  const registerPushTokenBody = (deviceToken: string) => ({
+    deviceToken,
+    platformName: "android" as const
   })
 })

--- a/APILambda/user/registerPushToken.ts
+++ b/APILambda/user/registerPushToken.ts
@@ -1,0 +1,42 @@
+import { z } from "zod"
+import { ValidatedRouter } from "../validation.js"
+import { SQLExecutable, conn } from "TiFBackendUtils"
+
+const RegisterPushTokenRequestSchema = z.object({
+  deviceToken: z.string().nonempty()
+})
+
+/**
+ * Adds the push notification registration endpoint.
+ */
+export const createRegisterPushTokenRouter = (router: ValidatedRouter) => {
+  router.postWithValidation(
+    "/notifications/push/register",
+    { bodySchema: RegisterPushTokenRequestSchema },
+    async (req, res) => {
+      return upsertPushToken(
+        conn,
+        res.locals.selfId,
+        req.body.deviceToken
+      ).mapSuccess((result) =>
+        res.status(result === "inserted" ? 201 : 204).send()
+      )
+    }
+  )
+}
+
+const upsertPushToken = (
+  conn: SQLExecutable,
+  userId: string,
+  deviceToken: string
+) =>
+  conn
+    .queryResult(
+      "INSERT IGNORE INTO pushTokens (userId, deviceToken) VALUES (:userId, :deviceToken)",
+      { userId, deviceToken }
+    )
+    .mapSuccess((result) => {
+      return result.rowsAffected > 0
+        ? ("inserted" as const)
+        : ("no-change" as const)
+    })


### PR DESCRIPTION
Adds an endpoint for registering device push tokens. Each token is registered with a platform name, currently either `"apple"` or `"android"`, but I suppose this could theoretically include other wearable devices like fitbit in the future.

I decided to create a separate id primary key for the table instead of doing an enormous composite key as that would've been the only way to ensure uniqueness of records otherwise.

The endpoint 400s if you try to insert an already existing token, and 201s on success with no body.