### PR TITLE
Remove no-use-before-define in eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,96 +1,105 @@
 {
-    "env": {
-      "browser": true,
-      "es2021": true,
-      "jest/globals": true
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "jest/globals": true
+  },
+  "extends": [
+    "plugin:react/recommended",
+    "standard",
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
     },
-    "extends": [
-      "plugin:react/recommended", 
-      "standard", 
-      "eslint:recommended",
-      "plugin:@typescript-eslint/recommended"
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-      "ecmaFeatures": {
-        "jsx": true
-      },
-      "ecmaVersion": "latest",
-      "sourceType": "module"
-    },
-    "plugins": [
-      "react",
-      "react-hooks",
-      "react-native",
-      "@typescript-eslint",
-      "jest",
-      "import"
-    ],
-    "settings": {
-      "react": {
-        "version": "detect"
-      }
-    },
-    "rules": {
-      "import/extensions": ["error", "always", {
-        "js": "always"
-      }],
-      "no-restricted-imports": ["error", {
-        "paths": [{
-          "name": "express",
-          "importNames": ["Router"],
-          "message": "Use 'ValidatedRouter' instead."
-        }]
-      }],
-      "semi": ["error", "never"],
-      "quotes": ["error", "double"],
-      "no-unused-vars": "warn",
-      "eqeqeq": "warn",
-      "react/jsx-key": "warn",
-      "react-hooks/rules-of-hooks": "error",
-      "react-hooks/exhaustive-deps": "warn",
-      "spaced-comment": "warn",
-      "space-in-parens": "error",
-      "computed-property-spacing": "error",
-      "array-bracket-spacing": "error",
-      "object-curly-spacing": "error",
-      "comma-spacing": "error",
-      "indent": ["error", 2],
-      "@typescript-eslint/naming-convention": [
-        "warn",
-        {
-          "selector": [
-            "function",
-            "objectLiteralProperty",
-            "objectLiteralMethod"
-          ],
-          "format": ["PascalCase", "camelCase"]
-        },
-        { "selector": "typeLike", "format": ["PascalCase"] },
-        { "selector": "typeParameter", "format": ["PascalCase"] },
-        { "selector": "interface", "format": ["PascalCase"] }
-      ]
-    },
-    "globals": {
-      "RequestInfo": "readonly",
-      "RequestInit": "readonly",
-      "JSX": "readonly",
-      "NodeJS": "readonly",
-      "__DEV__": "readonly"
-    },
-    "overrides": [
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": [
+    "react",
+    "react-hooks",
+    "react-native",
+    "@typescript-eslint",
+    "jest",
+    "import"
+  ],
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
+  "rules": {
+    "import/extensions": [
+      "error",
+      "always",
       {
-        "files": ["*.test.js", "*.test.ts", "*.test.tsx"],
-        "rules": {
-          "jest/valid-expect": 0,
-          "no-undef": 0,
-          "react/react-in-jsx-scope": 0,
-          "jest/no-disabled-tests": "warn",
-          "jest/no-focused-tests": "error",
-          "jest/no-identical-title": "error",
-          "jest/prefer-to-have-length": "warn"
-        }
+        "js": "always"
       }
+    ],
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "express",
+            "importNames": ["Router"],
+            "message": "Use 'ValidatedRouter' instead."
+          }
+        ]
+      }
+    ],
+    "semi": ["error", "never"],
+    "quotes": ["error", "double"],
+    "no-unused-vars": "warn",
+    "no-use-before-define": "off",
+    "eqeqeq": "warn",
+    "react/jsx-key": "warn",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
+    "spaced-comment": "warn",
+    "space-in-parens": "error",
+    "computed-property-spacing": "error",
+    "array-bracket-spacing": "error",
+    "object-curly-spacing": "error",
+    "comma-spacing": "error",
+    "indent": ["error", 2],
+    "@typescript-eslint/naming-convention": [
+      "warn",
+      {
+        "selector": [
+          "function",
+          "objectLiteralProperty",
+          "objectLiteralMethod"
+        ],
+        "format": ["PascalCase", "camelCase"]
+      },
+      { "selector": "typeLike", "format": ["PascalCase"] },
+      { "selector": "typeParameter", "format": ["PascalCase"] },
+      { "selector": "interface", "format": ["PascalCase"] }
     ]
+  },
+  "globals": {
+    "RequestInfo": "readonly",
+    "RequestInit": "readonly",
+    "JSX": "readonly",
+    "NodeJS": "readonly",
+    "__DEV__": "readonly"
+  },
+  "overrides": [
+    {
+      "files": ["*.test.js", "*.test.ts", "*.test.tsx"],
+      "rules": {
+        "jest/valid-expect": 0,
+        "no-undef": 0,
+        "react/react-in-jsx-scope": 0,
+        "jest/no-disabled-tests": "warn",
+        "jest/no-focused-tests": "error",
+        "jest/no-identical-title": "error",
+        "jest/prefer-to-have-length": "warn"
+      }
+    }
+  ]
 }
-  

--- a/TiFBackendUtils/result.ts
+++ b/TiFBackendUtils/result.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-use-before-define */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
@@ -174,7 +173,9 @@ export class FailureResult<Success, Failure> {
 /**
  * A result that handles a promise to a {@link Result} in a way such that it can be used like a normal synchronous result.
  */
-export class PromiseResult<Success, Failure> extends Promise<Result<Success, Failure>> {
+export class PromiseResult<Success, Failure> extends Promise<
+  Result<Success, Failure>
+> {
   constructor (executor) {
     if (typeof executor !== "function") {
       throw new TypeError("Promise resolver " + executor + " is not a function")


### PR DESCRIPTION
We're not programming in C where everything needs to be defined before its usage, but rather something else (I think). This linter rule is just annoying and adds little value since it can force internals of a file to the top of the file rather than putting the exported stuff at the top.