### PR TITLE
Return a response from register push token

### DIFF
--- a/APILambda/user/registerPushToken.test.ts
+++ b/APILambda/user/registerPushToken.test.ts
@@ -1,21 +1,20 @@
 import { randomUUID } from "crypto"
-import {
-  callRegisterPushToken
-} from "../test/apiCallers/users.js"
-import { withEmptyResponseBody } from "../test/assertions.js"
+import { callRegisterPushToken } from "../test/apiCallers/users.js"
 import { createUserFlow } from "../test/userFlows/users.js"
 
 describe("RegisterPushToken tests", () => {
+  const TEST_SUCCESS_RESPONSE = {
+    status: 201,
+    body: { status: "inserted" }
+  }
+
   it("should 201 when registering a new push token", async () => {
     const { token: userToken } = await createUserFlow()
     const resp = await callRegisterPushToken(
       userToken,
       registerPushTokenBody(randomUUID())
     )
-    expect(withEmptyResponseBody(resp)).toMatchObject({
-      status: 201,
-      body: ""
-    })
+    expect(resp).toMatchObject(TEST_SUCCESS_RESPONSE)
   })
 
   it("should 400 when registering an existing push token on the same platform", async () => {
@@ -39,10 +38,7 @@ describe("RegisterPushToken tests", () => {
       token,
       registerPushTokenBody(randomUUID())
     )
-    expect(withEmptyResponseBody(resp)).toMatchObject({
-      status: 201,
-      body: ""
-    })
+    expect(resp).toMatchObject(TEST_SUCCESS_RESPONSE)
   })
 
   const registerPushTokenBody = (pushToken: string) => ({

--- a/APILambda/user/registerPushToken.ts
+++ b/APILambda/user/registerPushToken.ts
@@ -26,7 +26,7 @@ export const createRegisterPushTokenRouter = (router: ValidatedRouter) => {
         ...req.body,
         userId: res.locals.selfId
       })
-        .mapSuccess(() => res.status(201).send())
+        .mapSuccess((status) => res.status(201).send({ status }))
         .mapFailure((error) => res.status(400).send({ error }))
     }
   )


### PR DESCRIPTION
We were returning an empty response from a 201 which goes against our convention of having 204 being the empty response. Since I still think 201 semantically makes the most sense for this endpoint, I opted to return a simple object so that we don't have to ruin our API client code on the frontend for this 1 special case.