### PR TITLE
Event/hcai/get attendees arrival status

### DIFF
--- a/APILambda/events/getAttendees.test.ts
+++ b/APILambda/events/getAttendees.test.ts
@@ -303,6 +303,38 @@ describe("Testing for getting attendees list endpoint", () => {
     })
   })
 
+  it("should return 200 if going past last page of attendees list", async () => {
+    const firstPageCursorResp = encodeAttendeesListCursor()
+    let resp = await callGetAttendees(
+      attendeeTestToken,
+      eventTestId,
+      firstPageCursorResp,
+      paginationLimit
+    )
+
+    const lastPageCursorResp = resp.body.nextPageCursor
+
+    resp = await callGetAttendees(
+      attendeeTestToken,
+      eventTestId,
+      lastPageCursorResp,
+      paginationLimit
+    )
+
+    resp.body.nextPageCursor = decodeAttendeesListCursor(
+      resp.body.nextPageCursor
+    )
+
+    expect(resp).toMatchObject({
+      status: 200,
+      body: {
+        attendees: [],
+        nextPageCursor: lastPageCursorResponse,
+        attendeesCount: 2
+      }
+    })
+  })
+
   it("check that attendees who arrived first are on top of the attendees list", async () => {
     const numOfAdditionalAttendees = 2
     const allAttendeesResp = await getAllAttendeesListResponse(
@@ -334,12 +366,16 @@ describe("Testing for getting attendees list endpoint", () => {
           {
             id: allAttendees[0].id,
             name: allAttendees[0].name,
-            arrivalStatus: true
+            joinTimestamp: allAttendees[0].joinTimestamp,
+            arrivalStatus: true,
+            arrivedAt: allAttendees[0].arrivedAt
           },
           {
             id: allAttendees[1].id,
             name: allAttendees[1].name,
-            arrivalStatus: true
+            joinTimestamp: allAttendees[1].joinTimestamp,
+            arrivalStatus: true,
+            arrivedAt: allAttendees[1].arrivedAt
           }
         ],
         nextPageCursor: getNextPageCursorResp(allAttendees, 1),
@@ -369,13 +405,17 @@ describe("Testing for getting attendees list endpoint", () => {
         attendees: [
           {
             id: allAttendees[2].id,
+            joinTimestamp: allAttendees[2].joinTimestamp,
             name: allAttendees[2].name,
-            arrivalStatus: false
+            arrivalStatus: false,
+            arrivedAt: allAttendees[2].arrivedAt
           },
           {
             id: allAttendees[3].id,
+            joinTimestamp: allAttendees[3].joinTimestamp,
             name: allAttendees[3].name,
-            arrivalStatus: false
+            arrivalStatus: false,
+            arrivedAt: allAttendees[3].arrivedAt
           }
         ],
         nextPageCursor: lastPageCursorResponse,

--- a/APILambda/events/getAttendees.test.ts
+++ b/APILambda/events/getAttendees.test.ts
@@ -309,6 +309,9 @@ describe("Testing for getting attendees list endpoint", () => {
       numOfAdditionalAttendees
     )
 
+    console.log("alll")
+    console.log(allAttendeesResp.body)
+
     const allAttendees = allAttendeesResp.body.attendees
 
     allAttendeesResp.body.nextPageCursor = decodeAttendeesListCursor(
@@ -334,12 +337,12 @@ describe("Testing for getting attendees list endpoint", () => {
           {
             id: allAttendees[0].id,
             name: allAttendees[0].name,
-            arrivalStatus: 1
+            arrivalStatus: true
           },
           {
             id: allAttendees[1].id,
             name: allAttendees[1].name,
-            arrivalStatus: 1
+            arrivalStatus: true
           }
         ],
         nextPageCursor: getNextPageCursorResp(allAttendees, 1),
@@ -370,12 +373,12 @@ describe("Testing for getting attendees list endpoint", () => {
           {
             id: allAttendees[2].id,
             name: allAttendees[2].name,
-            arrivalStatus: 0
+            arrivalStatus: false
           },
           {
             id: allAttendees[3].id,
             name: allAttendees[3].name,
-            arrivalStatus: 0
+            arrivalStatus: false
           }
         ],
         nextPageCursor: lastPageCursorResponse,

--- a/APILambda/events/getAttendees.test.ts
+++ b/APILambda/events/getAttendees.test.ts
@@ -308,10 +308,7 @@ describe("Testing for getting attendees list endpoint", () => {
     const allAttendeesResp = await getAllAttendeesListResponse(
       numOfAdditionalAttendees
     )
-
-    console.log("alll")
-    console.log(allAttendeesResp.body)
-
+    
     const allAttendees = allAttendeesResp.body.attendees
 
     allAttendeesResp.body.nextPageCursor = decodeAttendeesListCursor(

--- a/APILambda/events/getAttendees.ts
+++ b/APILambda/events/getAttendees.ts
@@ -41,7 +41,7 @@ const mapDatabaseAttendee = (sqlResult: DatabaseAttendeeWithRelation) => {
     profileImageURL: sqlResult.profileImageURL,
     handle: sqlResult.handle,
     arrivedAt: sqlResult.arrivedAt,
-    arrivalStatus: sqlResult.arrivalStatus,
+    arrivalStatus: !!sqlResult.arrivalStatus,
     relations: {
       youToThem: sqlResult.youToThem ?? "not-friends",
       themToYou: sqlResult.themToYou ?? "not-friends"
@@ -126,7 +126,7 @@ const getAttendees = (
         ua.arrivedAt,
         MAX(CASE WHEN ur.fromUserId = :userId THEN ur.status END) AS youToThem,
         MAX(CASE WHEN ur.toUserId = :userId THEN ur.status END) AS themToYou,
-        CASE WHEN ua.arrivedAt IS NOT NULL THEN 1 ELSE 0 END AS arrivalStatus
+        CASE WHEN ua.arrivedAt IS NOT NULL THEN true ELSE false END AS arrivalStatus
         FROM user AS u 
         INNER JOIN eventAttendance AS ea ON u.id = ea.userId 
         INNER JOIN event AS e ON ea.eventId = e.id

--- a/APILambda/shared/Cursor.ts
+++ b/APILambda/shared/Cursor.ts
@@ -9,18 +9,20 @@ const defaultJoinDate = "1970-01-01T00:00:00Z"
 export const encodeAttendeesListCursor = (cursorObject?: {
   userId: string
   joinDate: Date | null
+  arrivedAt: Date | null
 }): string => {
-  const { userId, joinDate } = cursorObject
+  const { userId, joinDate, arrivedAt } = cursorObject
     ? cursorObject
     : {
         userId: "firstPage",
-        joinDate: null
+        joinDate: null,
+        arrivedAt: null
       }
-      
+
   const joinDateToEncode = joinDate ? joinDate : defaultJoinDate
-  const encodedCursor = Buffer.from(`${userId}|${joinDateToEncode}`).toString(
-    "base64"
-  )
+  const encodedCursor = Buffer.from(
+    `${userId}|${joinDateToEncode}|${arrivedAt}`
+  ).toString("base64")
   return encodedCursor
 }
 
@@ -32,21 +34,24 @@ export const encodeAttendeesListCursor = (cursorObject?: {
  */
 export const decodeAttendeesListCursor = (
   cursor: string | undefined
-): { userId: string; joinDate: Date | null } => {
+): { userId: string; joinDate: Date | null; arrivedAt: Date | null } => {
   let joinDate = new Date(defaultJoinDate)
+  let arrivedAt = null
 
   if (cursor === undefined) {
-    return { userId: "firstPage", joinDate }
+    return { userId: "firstPage", joinDate, arrivedAt: null }
   }
 
   const decodedString = Buffer.from(cursor, "base64").toString("utf-8")
-  const [decodedUserId, decodedJoinDate] = decodedString.split("|")
+  const [decodedUserId, decodedJoinDate, decodedArrivedAt] =
+    decodedString.split("|")
 
   if (decodedUserId === "lastPage") {
-    return { userId: "lastPage", joinDate: null }
-  } else if (decodedJoinDate !== defaultJoinDate) {
-    joinDate = new Date(decodedJoinDate)
+    return { userId: "lastPage", joinDate: null, arrivedAt: null }
   }
+  joinDate =
+    decodedJoinDate !== defaultJoinDate ? new Date(decodedJoinDate) : joinDate
+  arrivedAt = decodedArrivedAt !== "null" ? new Date(decodedArrivedAt) : null
 
-  return { userId: decodedUserId, joinDate }
+  return { userId: decodedUserId, joinDate, arrivedAt }
 }

--- a/APILambda/shared/SQL.ts
+++ b/APILambda/shared/SQL.ts
@@ -23,12 +23,20 @@ export type DatabaseAttendee = {
   joinTimestamp: Date
   profileImageURL?: string
   handle: string
+  arrivalStatus: boolean
+  arrivedAt: Date
 }
 
 export type PaginatedAttendeesResponse = {
   nextPageCursor: string
   attendeesCount: number
   attendees: DatabaseAttendee[]
+}
+
+export type AttendeesCursorResponse = {
+  userId: string,
+  joinDate: Date | null,
+  arrivedAt: Date | null
 }
 
 export type EventAttendee = {


### PR DESCRIPTION
Updates for attendees list endpoint arrival status:
- The attendees list contains the arrival status boolean and arrivedAt
- SQL queries takes in arrivedAt parameter and sorts by arrivedAt in ascending order
- The cursor has been updated to include arrivedAt
- Added test for checking that arrivedAt attendees are at the top of the list