### PR TITLE
fix lambda deployment

### DIFF
--- a/.github/workflows/build_api.yml
+++ b/.github/workflows/build_api.yml
@@ -97,6 +97,7 @@ jobs:
           shopt -s extglob
           cp -R !(test|.github|dist|*.ts) dist/
           cd dist
+          rm -rf test
           zip -r ../dist.zip .
       
       - name: Set output path

--- a/APILambda/tsconfig.json
+++ b/APILambda/tsconfig.json
@@ -15,6 +15,7 @@
   "exclude": [
     "**/*.test.ts",
     "**/*.spec.ts",
-    "node_modules"
+    "node_modules",
+    "test"
   ]
 }


### PR DESCRIPTION
Building the apilambda now includes the geocodinglambda in the output. Causes aws to not work. Remove the test folder from the build process so this doesnt happen.