### PR TITLE
update endpoints improvement

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -93,7 +93,7 @@ jobs:
               fi
           done
           stageName="staging"
-          aws apigateway put-rest-api --rest-api-id 623qsegfb9 --fail-on-warnings --debug true --mode overwrite --body fileb://APILambda/specs.json
+          aws apigateway put-rest-api --rest-api-id 623qsegfb9 --fail-on-warnings --debug --mode overwrite --body fileb://APILambda/specs.json
           aws apigateway create-deployment --rest-api-id 623qsegfb9 --stage-name $stageName --description 'Deployed'
 
       - name: Install dependencies

--- a/APILambda/user/settings/getUserSettings.ts
+++ b/APILambda/user/settings/getUserSettings.ts
@@ -1,36 +1,7 @@
-import { SQLExecutable, conn, success } from "TiFBackendUtils"
+import { conn } from "TiFBackendUtils"
 import { ServerEnvironment } from "../../env.js"
 import { ValidatedRouter } from "../../validation.js"
-import { userWithIdExists } from "../SQL.js"
-import { DatabaseUserSettings } from "./models.js"
-import { DEFAULT_USER_SETTINGS } from "./updateUserSettings.js"
-
-/**
- * Queries a given user's settings. If the user has never edited their settings,
- * undefined will be returned if no errors occur.
- *
- * @param conn the query executor to use
- * @param id the id of the user
- * @returns a result that indicates that the user is not found, or their current settings
- */
-export const queryUserSettings = (conn: SQLExecutable, userId: string) =>
-  userWithIdExists(conn, userId).flatMapSuccess(() =>
-    conn.queryFirstResult<DatabaseUserSettings>(
-      `
-    SELECT 
-      isAnalyticsEnabled, 
-      isCrashReportingEnabled, 
-      isEventNotificationsEnabled, 
-      isMentionsNotificationsEnabled, 
-      isChatNotificationsEnabled, 
-      isFriendRequestNotificationsEnabled,
-      lastUpdatedAt
-    FROM userSettings
-    WHERE userId = :userId
-  `,
-      { userId }
-    )
-  )
+import { queryUserSettings } from "./userSettingsQuery.js"
 
 export const getUserSettingsRouter = (
   environment: ServerEnvironment,
@@ -41,7 +12,6 @@ export const getUserSettingsRouter = (
    */
   router.getWithValidation("/self/settings", {}, (_, res) =>
     queryUserSettings(conn, res.locals.selfId)
-      .flatMapFailure(() => success(DEFAULT_USER_SETTINGS))
       .mapSuccess(settings => res.status(200).json(settings).send())
   )
 }

--- a/APILambda/user/settings/models.ts
+++ b/APILambda/user/settings/models.ts
@@ -16,5 +16,3 @@ export const UserSettingsSchema = z.object({
  * A type representing a user's settings.
  */
 export type UserSettings = z.infer<typeof UserSettingsSchema>
-
-export type DatabaseUserSettings = UserSettings & { lastUpdatedAt: Date }

--- a/APILambda/user/settings/updateUserSettings.test.ts
+++ b/APILambda/user/settings/updateUserSettings.test.ts
@@ -57,6 +57,28 @@ describe("Update Settings tests", () => {
     expect(settings2LastUpdatedAt.getTime()).toBeGreaterThanOrEqual(
       settings1LastUpdatedAt.getTime()
     )
+
+    const updateResp3 = await callPatchSettings(token, {
+      isCrashReportingEnabled: true
+    })
+    expect(withEmptyResponseBody(updateResp3)).toMatchObject({
+      status: 204,
+      body: ""
+    })
+
+    const settings3Resp = await callGetSettings(token)
+    expect(settings3Resp).toMatchObject({
+      status: 200,
+      body: expect.objectContaining({
+        isAnalyticsEnabled: true,
+        isCrashReportingEnabled: true,
+        isEventNotificationsEnabled: true,
+        isMentionsNotificationsEnabled: true,
+        isChatNotificationsEnabled: false,
+        isFriendRequestNotificationsEnabled: true,
+        lastUpdatedAt: expect.anything()
+      })
+    })
   })
 
   it("should 400 for an invalid settings body", async () => {

--- a/APILambda/user/settings/userSettingsQuery.ts
+++ b/APILambda/user/settings/userSettingsQuery.ts
@@ -1,0 +1,35 @@
+import { DBuserSettings, SQLExecutable, success } from "TiFBackendUtils"
+import { userWithIdExists } from "../SQL.js"
+
+/**
+ * The default user settings, which enables all fields.
+ */
+const DEFAULT_USER_SETTINGS = {
+  isAnalyticsEnabled: true,
+  isCrashReportingEnabled: true,
+  isEventNotificationsEnabled: true,
+  isMentionsNotificationsEnabled: true,
+  isChatNotificationsEnabled: true,
+  isFriendRequestNotificationsEnabled: true
+} as const
+
+/**
+ * Queries a given user's settings. If the user has never edited their settings,
+ * undefined will be returned if no errors occur.
+ *
+ * @param conn the query executor to use
+ * @param id the id of the user
+ * @returns a result that indicates that the user is not found, or their current settings
+ */
+export const queryUserSettings = (conn: SQLExecutable, userId: string) =>
+  userWithIdExists(conn, userId).flatMapSuccess(() =>
+    conn.queryFirstResult<DBuserSettings>(
+      `
+    SELECT *
+    FROM userSettings
+    WHERE userId = :userId
+  `,
+      { userId }
+    )
+  )
+    .flatMapFailure(() => success(DEFAULT_USER_SETTINGS))

--- a/APILambda/user/updateUserProfile.ts
+++ b/APILambda/user/updateUserProfile.ts
@@ -1,17 +1,18 @@
-import { SQLExecutable, UserHandle, conn, success } from "TiFBackendUtils"
+import { DBuser, NullablePartial, SQLExecutable, UserHandle, conn, success } from "TiFBackendUtils"
 import { z } from "zod"
 import { ServerEnvironment } from "../env.js"
 import { ValidatedRouter } from "../validation.js"
 import { userWithHandleDoesNotExist } from "./SQL.js"
-import { DatabaseUser } from "./models.js"
 
 const UpdateUserRequestSchema = z.object({
   name: z.string().optional(),
   bio: z.string().max(250).optional(),
-  handle: UserHandle.schema.optional()
+  handle: UserHandle.schema.optional().transform(handle => handle?.rawValue)
 })
 
-export type UpdateUserRequest = z.infer<typeof UpdateUserRequestSchema>
+type UpdateUserRequest = z.infer<typeof UpdateUserRequestSchema>
+
+type EditableProfileFields = Pick<DBuser, "bio" | "handle" | "name">
 
 /**
  * Creates routes related to user operations.
@@ -31,7 +32,7 @@ export const updateUserProfileRouter = (
     { bodySchema: UpdateUserRequestSchema },
     (req, res) =>
       conn
-        .transaction((tx) => updateProfile(tx, res.locals.selfId, req.body))
+        .transaction((tx) => updateProfileTransaction(tx, res.locals.selfId, req.body))
         .mapFailure((error) => res.status(400).json({ error }))
         .mapSuccess(() => res.status(204).send())
   )
@@ -39,41 +40,26 @@ export const updateUserProfileRouter = (
   return router
 }
 
+const updateProfileTransaction = (
+  conn: SQLExecutable,
+  userId: string,
+  updatedProfile: UpdateUserRequest
+) =>
+  (updatedProfile.handle ? userWithHandleDoesNotExist(conn, updatedProfile.handle) : success())
+    .flatMapSuccess(() => updateProfile(conn, userId, updatedProfile))
+
 const updateProfile = (
   conn: SQLExecutable,
   userId: string,
-  request: UpdateUserRequest
-) =>
-  (request.handle ? userWithHandleDoesNotExist(conn, request.handle?.rawValue) : success())
-    .flatMapSuccess(() => getProfile(conn, userId))
-    .flatMapSuccess((profile) => {
-      const handle = request.handle?.rawValue ?? profile.handle
-      const name = request.name ?? profile.name
-      const updatedProfile = { ...profile, ...request, handle, name }
-      return overwriteProfile(conn, userId, updatedProfile)
-    })
-
-type DatabaseUserProfile = {
-  name: string
-  handle: string
-  bio?: string
-}
-
-const overwriteProfile = (
-  conn: SQLExecutable,
-  userId: string,
-  profile: DatabaseUserProfile
+  { handle = null, name = null, bio = null }: NullablePartial<EditableProfileFields>
 ) =>
   conn
     .queryResults(
-      "UPDATE user SET name = :name, bio = :bio, handle = :handle WHERE id = :userId",
-      { ...profile, userId }
+      `UPDATE user 
+      SET 
+      name = COALESCE(:name, name),
+      bio = COALESCE(:bio, bio), 
+      handle = COALESCE(:handle, handle)
+      WHERE id = :userId`,
+      { handle, name, bio, userId }
     )
-
-const getProfile = (conn: SQLExecutable, userId: string) =>
-  conn
-    .queryFirstResult<Pick<DatabaseUser, "bio" | "handle" | "name">>(
-      "SELECT name, handle, bio FROM user WHERE id = :userId",
-      { userId }
-    )
-    .withFailure("user-not-found" as const)

--- a/TiFBackendUtils/index.ts
+++ b/TiFBackendUtils/index.ts
@@ -6,3 +6,5 @@ export * from "./TifEventUtils.js"
 export * from "./UserHandle.js"
 export * from "./location.js"
 export * from "./result.js"
+export * from "./types/index.js"
+

--- a/TiFBackendUtils/types/index.ts
+++ b/TiFBackendUtils/types/index.ts
@@ -1,0 +1,3 @@
+export type NullablePartial<T> = {
+    [P in keyof T]?: T[P] | null;
+};


### PR DESCRIPTION
With our previous versions of updateUserProfile / updateUserSettings, we needed at least 2 SQL statements. After experimentation, they can be combined into 1 using COALESCE.
+ move querygetusersettings to new file to make it easier to reuse