### PR TITLE
fix creating events without timezones

### DIFF
--- a/APILambda/events/getEventById.ts
+++ b/APILambda/events/getEventById.ts
@@ -95,7 +95,7 @@ export const getEventByIdRouter = (
                 ? success(res
                   .status(403)
                   .json(getEventWhenBlockedResponse(dbUser, event.title, Number(event.id))))
-                : setEventAttendeesFields(tx, [event], res.locals.selfId).flatMapSuccess((events) => refactorEventsToMatchTifEvent(events))
+                : setEventAttendeesFields(tx, [event], res.locals.selfId).flatMapSuccess((events) => refactorEventsToMatchTifEvent(events))// TODO: if no timezone, return error
                   .mapSuccess((event) => res.status(200).json(event[0]))
             )
           )

--- a/GeocodingLambda/handler.test.ts
+++ b/GeocodingLambda/handler.test.ts
@@ -1,20 +1,39 @@
-/* eslint-disable no-multi-str */
-// address formatting
-
-import { conn, failure, success } from "TiFBackendUtils"
+import { Placemark, conn, failure, success } from "TiFBackendUtils"
 import { handler } from "./index.js"
+
+const resetDB = async () => conn.queryResults("DELETE FROM location")
+const geocode = async () => handler({ latitude: 36.99813840222285, longitude: -122.05564377465653 })
 
 describe("Geocoding lambda tests", () => {
   it("Should insert a placemark with the proper address with the given lat/lon", async () => {
-    await conn.queryResults("DELETE FROM location")
+    await resetDB()
 
-    const result = await handler({ latitude: 36.99813840222285, longitude: -122.05564377465653 })
+    const result = await geocode()
 
     expect(result).toMatchObject(success("placemark-successfully-inserted"))
+
+    const address = await conn.queryFirstResult<Placemark>("SELECT * FROM location WHERE lat = :latitude AND lon = :longitude", { latitude: 36.9981384022, longitude: -122.0556437747 })
+    expect(address.value).toMatchObject({
+      city: "Westside",
+      country: null,
+      isoCountryCode: "USA",
+      lat: 36.9981384022,
+      lon: -122.0556437747,
+      name: "420 Hagar Dr, Santa Cruz, CA 95064, United States",
+      // TODO: Rename to match shared models
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      postal_code: "95064",
+      region: null,
+      street: "Hagar Dr",
+      // TODO: Rename to match shared models
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      street_num: "420",
+      timeZone: "America/Los_Angeles"
+    })
   })
 
   it("Should return when a placemark already exists", async () => {
-    const result = await handler({ latitude: 36.99813840222285, longitude: -122.05564377465653 })
+    const result = await geocode()
 
     expect(result).toMatchObject(failure("placemark-already-exists"))
   })

--- a/GeocodingLambda/index.ts
+++ b/GeocodingLambda/index.ts
@@ -34,7 +34,10 @@ export const handler: any = exponentialFunctionBackoff<
         }).then(placemark => success(placemark))
       ))
     .flatMapSuccess((placemark: Placemark) => {
-      const timeZone = getTimeZone({ latitude, longitude })[0]
+      const timeZone = placemark.timezone ?? getTimeZone({ latitude, longitude })[0]
+      if (!timeZone) { // should we throw if no address exists? ex. pacific ocean
+        throw new Error(`Could not find timezone for ${JSON.stringify(location)}.`)
+      }
       return addPlacemarkToDB(conn, placemark, timeZone)
     })
     .mapSuccess(() => "placemark-successfully-inserted" as const)

--- a/GeocodingLambda/utils.ts
+++ b/GeocodingLambda/utils.ts
@@ -18,7 +18,7 @@ const locationClient = new LocationClient({ region: process.env.AWS_REGION })
  */
 export const SearchForPositionResultToPlacemark = (
   location: LocationCoordinate2D,
-  place: Place
+  place?: Place
 ): Placemark => {
   return {
     lat: location.latitude,
@@ -34,7 +34,8 @@ export const SearchForPositionResultToPlacemark = (
     postalCode: place?.PostalCode,
     region: place?.Region,
     isoCountryCode: place?.Country,
-    country: undefined
+    country: undefined,
+    timezone: place?.TimeZone?.Name
   }
 }
 
@@ -49,9 +50,7 @@ export const SearchClosestAddressToCoordinates = async (
       Language: "en-US"
     })
   )
-  if (!response.Results?.[0]?.Place) {
-    throw new Error()
-  }
+
   return SearchForPositionResultToPlacemark(
     location,
     response.Results?.[0]?.Place

--- a/TiFBackendUtils/location.ts
+++ b/TiFBackendUtils/location.ts
@@ -26,4 +26,5 @@ export interface Placemark {
   postalCode?: string | null,
   region?: string | null,
   isoCountryCode?: string | null
+  timezone?: string | null,
 }


### PR DESCRIPTION
Sometimes AWS does not return a valid address for given coordinates. If a valid timezone still exists for that address, we still want to mark the operation successful and add it to the db.