### PR TITLE
staging lambdas will have their own versions now

### DIFF
--- a/.github/workflows/build_api.yml
+++ b/.github/workflows/build_api.yml
@@ -62,15 +62,14 @@ jobs:
         run: |
           cd TiFBackendUtils
           shopt -s extglob
-          cp -R !(test|.github|dist|*.ts) dist/
+          cp -R node_modules dist/
+          cp *.json dist/
           cd dist
           npm pack
 
       - name: Install dependencies
         run: |
-          cd GeocodingLambda
-          npm ci
-          cd ../APILambda
+          cd APILambda
           npm ci
           npm install ../TiFBackendUtils/dist/TiFBackendUtils-1.0.0.tgz
       
@@ -95,9 +94,9 @@ jobs:
         run: |
           cd APILambda
           shopt -s extglob
-          cp -R !(test|.github|dist|*.ts) dist/
+          cp -R node_modules dist/
+          cp *.json dist/
           cd dist
-          rm -rf test
           zip -r ../dist.zip .
       
       - name: Set output path

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -92,7 +92,17 @@ jobs:
                   sleep 10
               fi
           done
-          stageName="staging"
+          VERSION_NUMBER=$(aws lambda publish-version --function-name lambdaSQLRoute | jq -r '.Version')
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            stageName="prod"
+            sed -i 's/:dev/:prod/g' APILambda/specs.json
+            sed -i 's/\"dev\"/\"prod\"/g' APILambda/specs.json
+          else
+            stageName="staging"
+            sed -i 's/:dev/:staging/g' APILambda/specs.json
+            sed -i 's/\"dev\"/\"staging\"/g' APILambda/specs.json
+          fi
+          aws lambda update-alias --function-name lambdaSQLRoute --name $stageName --function-version $VERSION_NUMBER
           aws apigateway put-rest-api --rest-api-id 623qsegfb9 --fail-on-warnings --debug --mode overwrite --body fileb://APILambda/specs.json
           aws apigateway create-deployment --rest-api-id 623qsegfb9 --stage-name $stageName --description 'Deployed'
 
@@ -184,13 +194,14 @@ jobs:
                   sleep 10
               fi
           done
+          VERSION_NUMBER=$(aws lambda publish-version --function-name lambdaSQLRoute | jq -r '.Version')
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             stageName="prod"
-            VERSION_NUMBER=$(aws lambda publish-version --function-name lambdaSQLRoute | jq -r '.Version')
-            aws lambda update-alias --function-name lambdaSQLRoute --name prod --function-version $VERSION_NUMBER
-            sed -i 's/:dev/:prod/g' APILambda/swagger.json
+            sed -i 's/:dev/:prod/g' APILambda/specs.json
           else
             stageName="staging"
+            sed -i 's/:dev/:staging/g' APILambda/specs.json
           fi
+          aws lambda update-alias --function-name lambdaSQLRoute --name $stageName --function-version $VERSION_NUMBER
           aws apigateway put-rest-api --rest-api-id 623qsegfb9 --fail-on-warnings --mode overwrite --body fileb://APILambda/specs.json
           aws apigateway create-deployment --rest-api-id 623qsegfb9 --stage-name $stageName --description 'Deployed'

--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -60,3 +60,70 @@ jobs:
 
   build:
     uses: ./.github/workflows/build_api.yml
+  
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: api-lambda
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      
+      - name: Update AWS Lambda env variables
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            DB_USERNAME=${{ secrets.DATABASE_USERNAME }}
+            DB_PASSWORD=${{ secrets.DATABASE_PASSWORD }}
+          else
+            DB_USERNAME=${{ secrets.DEV_DATABASE_USERNAME }}
+            DB_PASSWORD=${{ secrets.DEV_DATABASE_PASSWORD }}
+          fi
+
+          aws lambda update-function-configuration \
+            --function-name lambdaSQLRoute \
+            --environment "Variables={\
+              DATABASE_HOST=${{ secrets.DATABASE_HOST }},\
+              DATABASE_USERNAME=$DB_USERNAME,\
+              DATABASE_PASSWORD=$DB_PASSWORD,\
+              ABLY_KEY=${{ secrets.ABLY_KEY }},\
+              SLACK_APP_ID=${{ secrets.SLACK_APP_ID }},\
+              COGNITO_USER_POOL_ID=${{ secrets.COGNITO_USER_POOL_ID }}\
+            }"
+
+      - name: Deploy to AWS Lambda
+        run: |
+          aws lambda update-function-code --function-name lambdaSQLRoute --zip-file fileb://dist.zip
+          while true; do
+              update_status=$(aws lambda get-function --function-name lambdaSQLRoute | jq -r '.Configuration.LastUpdateStatus')
+
+              if [[ "$update_status" == "Successful" ]]; then
+                  echo "Update completed successfully."
+                  break
+              elif [[ "$update_status" == "Failed" ]]; then
+                  echo "Update failed."
+                  exit 1
+              else
+                  echo "Update in progress. Waiting..."
+                  sleep 10
+              fi
+          done
+          stageName="dev"
+          aws apigateway put-rest-api --rest-api-id 623qsegfb9 --fail-on-warnings --debug --mode overwrite --body fileb://APILambda/specs.json
+          aws apigateway create-deployment --rest-api-id 623qsegfb9 --stage-name $stageName --description 'Deployed'

--- a/APILambda/specs.json
+++ b/APILambda/specs.json
@@ -10,7 +10,7 @@
       "url": "https://623qsegfb9.execute-api.us-west-2.amazonaws.com/{basePath}",
       "variables": {
         "basePath": {
-          "default": "staging"
+          "default": "dev"
         }
       }
     }

--- a/APILambda/tsconfig.json
+++ b/APILambda/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "esnext",
     "target": "es2020",
     "strict": true,
-    "declaration": true,
+    "declaration": false,
     "outDir": "dist",
     "removeComments": true,
     "allowJs": true,


### PR DESCRIPTION
Problem: In order to test our backend changes live, we have to merge to development, then wait for staging to be deployed, and then test at https://623qsegfb9.execute-api.us-west-2.amazonaws.com/staging. If there are issues with aws integration, we need to make a new PR to fix it, then again merge the fix to development, then again test at the staging endpoint.

Solution:
In order to keep https://623qsegfb9.execute-api.us-west-2.amazonaws.com/staging in a stable state for front-end testing, we'll add a new stage :dev which will be updated for every PR to development. That way we can test new PRs on the :dev stage without having to merge into development or mess with :staging. The :dev stage can be accessed at https://623qsegfb9.execute-api.us-west-2.amazonaws.com/dev.

Details:
The :dev stage will always point to $LATEST version of the lambda. Every time we merge to development, a new version will be created and :staging will point to that newly created version. Same thing with prod. Every time we merge to prod, a new version will be created and :prod will point to that version.