### PR TITLE
remove pre commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,0 @@
-cd ./APILambda && npm run dbtots && npm run genapispecs


### PR DESCRIPTION
It takes too long to run dbtots and genapispecs for each commit. We will leave them as separate scripts for now