### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+# Pull Request Template
+You're free to modify or omit sections as relevant to your specific pull request.
+
+## Problem/Purpose
+Required for all PR's. Clearly describe the problems or issues that this pull request aims to address. This section helps reviewers understand the context and necessity of the changes.
+
+## Proposed Solution
+Give an overview of the approach taken to solve the problems listed above. Explain your thought process to give reviewers insight into the reasoning behind the decisions made for this PR.
+
+## Implementation Steps
+Outline the steps you took to implement the solution, including technical details.
+
+## Results
+Describe the deliverables or results of this PR, which may include screenshots, api responses, or example workflows to help reviewers understand the impact of these changes.
+
+## Warnings
+Highlight important changes that might affect the experience of other developers or end-users (ex. dependency updates, new environment variables, etc).
+
+## Other Changes
+Ideally your PR should remain focused on solving the given problem, but if other changes are included, explain them here.
+
+## Follow Ups
+If the PR is incremental or part of a larger ticket, list any remaining work that is not included in this PR, ex.:
+- Task 1 https://trello.com/c/jgUBLFjj
+- Task 2 https://trello.com/c/V1jk0XT9
+- Task 3 https://trello.com/c/XRgf2sDa


### PR DESCRIPTION
## Problem
PR quality should be improved.

## Proposed Solution
Add a PR template to encourage explaining the purpose and details of the PR. This should ensure every PR is meaningful.

## Steps
* Added pull_request_template.md file to .github folder

## Results
Opening a PR should pre-populate the form with the template.

## Warnings
Needs to be merged in to test.

TASK_pyLuAoOS