### PR TITLE
Add script to support npm ci postinstall

### DIFF
--- a/.github/workflows/deploy_api_to_staging.yml
+++ b/.github/workflows/deploy_api_to_staging.yml
@@ -50,12 +50,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        cd TiFBackendUtils
         npm ci
-        cd ../GeocodingLambda
-        npm ci
-        cd ../APILambda
-        npm ci
+      env:
+        CI: true
 
     - name: Authenticate with AWS Cognito and run tests
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
+        env:
+          CI: true
 
       - name: Check ESLint
         run: |

--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -39,13 +39,11 @@ jobs:
           
       - name: Install dependencies
         run: |
+          npm ci
           cd TiFBackendUtils
-          npm ci
           npm run dbtots
-          cd ../GeocodingLambda
-          npm ci
-          cd ../APILambda
-          npm ci
+        env:
+          CI: true
       
       - name: Validate openapi specs
         run: |
@@ -102,12 +100,9 @@ jobs:
         
     - name: Install dependencies
       run: |
-        cd TiFBackendUtils
         npm ci
-        cd ../GeocodingLambda
-        npm ci
-        cd ../APILambda
-        npm ci
+      env:
+        CI: true
 
     - name: Authenticate with AWS Cognito and run tests
       run: |

--- a/.github/workflows/test_geocoder.yml
+++ b/.github/workflows/test_geocoder.yml
@@ -37,10 +37,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          cd TiFBackendUtils
           npm ci
-          cd ../GeocodingLambda
-          npm ci
+        env:
+          CI: true
 
       - name: Run tests
         run: |

--- a/APILambda/package-lock.json
+++ b/APILambda/package-lock.json
@@ -62,6 +62,7 @@
         "mysql2": "^3.9.1",
         "patch-package": "^8.0.0",
         "ts-jest": "^29.1.1",
+        "ts-node": "^10.9.2",
         "typescript": "^4.9.5"
       },
       "peerDependencies": {
@@ -1923,8 +1924,6 @@
       "version": "0.8.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -1936,8 +1935,6 @@
       "version": "0.3.9",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -3215,30 +3212,22 @@
     "../TiFBackendUtils/node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "../TiFBackendUtils/node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "../TiFBackendUtils/node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "../TiFBackendUtils/node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "../TiFBackendUtils/node_modules/@types/babel__core": {
       "version": "7.20.1",
@@ -3356,8 +3345,6 @@
       "version": "8.10.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3369,8 +3356,6 @@
       "version": "8.2.0",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3426,9 +3411,7 @@
     "../TiFBackendUtils/node_modules/arg": {
       "version": "4.1.3",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "../TiFBackendUtils/node_modules/argparse": {
       "version": "1.0.10",
@@ -3865,9 +3848,7 @@
     "../TiFBackendUtils/node_modules/create-require": {
       "version": "1.1.1",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "../TiFBackendUtils/node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -3970,8 +3951,6 @@
       "version": "4.0.2",
       "dev": true,
       "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -6517,8 +6496,6 @@
       "version": "10.9.2",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -6671,9 +6648,7 @@
     "../TiFBackendUtils/node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "../TiFBackendUtils/node_modules/v8-to-istanbul": {
       "version": "9.1.0",
@@ -6813,8 +6788,6 @@
       "version": "3.1.1",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -24877,6 +24850,7 @@
         "node-fetch": "^3.3.2",
         "patch-package": "^8.0.0",
         "ts-jest": "^29.1.1",
+        "ts-node": "^10.9.2",
         "typescript": "^4.9.5"
       },
       "dependencies": {
@@ -26278,8 +26252,6 @@
         "@cspotcode/source-map-support": {
           "version": "0.8.1",
           "dev": true,
-          "optional": true,
-          "peer": true,
           "requires": {
             "@jridgewell/trace-mapping": "0.3.9"
           },
@@ -26287,8 +26259,6 @@
             "@jridgewell/trace-mapping": {
               "version": "0.3.9",
               "dev": true,
-              "optional": true,
-              "peer": true,
               "requires": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -27288,27 +27258,19 @@
         },
         "@tsconfig/node10": {
           "version": "1.0.9",
-          "dev": true,
-          "optional": true,
-          "peer": true
+          "dev": true
         },
         "@tsconfig/node12": {
           "version": "1.0.11",
-          "dev": true,
-          "optional": true,
-          "peer": true
+          "dev": true
         },
         "@tsconfig/node14": {
           "version": "1.0.3",
-          "dev": true,
-          "optional": true,
-          "peer": true
+          "dev": true
         },
         "@tsconfig/node16": {
           "version": "1.0.4",
-          "dev": true,
-          "optional": true,
-          "peer": true
+          "dev": true
         },
         "@types/babel__core": {
           "version": "7.20.1",
@@ -27409,15 +27371,11 @@
         },
         "acorn": {
           "version": "8.10.0",
-          "dev": true,
-          "optional": true,
-          "peer": true
+          "dev": true
         },
         "acorn-walk": {
           "version": "8.2.0",
-          "dev": true,
-          "optional": true,
-          "peer": true
+          "dev": true
         },
         "ansi-escapes": {
           "version": "4.3.2",
@@ -27447,9 +27405,7 @@
         },
         "arg": {
           "version": "4.1.3",
-          "dev": true,
-          "optional": true,
-          "peer": true
+          "dev": true
         },
         "argparse": {
           "version": "1.0.10",
@@ -27741,9 +27697,7 @@
         },
         "create-require": {
           "version": "1.1.1",
-          "dev": true,
-          "optional": true,
-          "peer": true
+          "dev": true
         },
         "cross-spawn": {
           "version": "7.0.3",
@@ -27796,9 +27750,7 @@
         },
         "diff": {
           "version": "4.0.2",
-          "dev": true,
-          "optional": true,
-          "peer": true
+          "dev": true
         },
         "diff-sequences": {
           "version": "29.4.3",
@@ -29411,8 +29363,6 @@
         "ts-node": {
           "version": "10.9.2",
           "dev": true,
-          "optional": true,
-          "peer": true,
           "requires": {
             "@cspotcode/source-map-support": "^0.8.0",
             "@tsconfig/node10": "^1.0.7",
@@ -29490,9 +29440,7 @@
         },
         "v8-compile-cache-lib": {
           "version": "3.0.1",
-          "dev": true,
-          "optional": true,
-          "peer": true
+          "dev": true
         },
         "v8-to-istanbul": {
           "version": "9.1.0",
@@ -29582,9 +29530,7 @@
         },
         "yn": {
           "version": "3.1.1",
-          "dev": true,
-          "optional": true,
-          "peer": true
+          "dev": true
         },
         "yocto-queue": {
           "version": "0.1.0",

--- a/GeocodingLambda/package-lock.json
+++ b/GeocodingLambda/package-lock.json
@@ -39,6 +39,7 @@
         "mysql2": "^3.9.1",
         "patch-package": "^8.0.0",
         "ts-jest": "^29.1.1",
+        "ts-node": "^10.9.2",
         "typescript": "^4.9.5"
       },
       "peerDependencies": {
@@ -8993,6 +8994,7 @@
         "node-fetch": "^3.3.2",
         "patch-package": "^8.0.0",
         "ts-jest": "^29.1.1",
+        "ts-node": "^10.9.2",
         "typescript": "^4.9.5"
       }
     },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "pr": "node --loader ts-node/esm ./TiFBackendUtils/node_modules/TiFShared/npm-scripts/auto-pr.ts",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,md}\"",
     "prepare": "husky",
-    "postinstall": "cd TiFBackendUtils && npm install && cd .. && cd APILambda && npm install && cd .. && cd GeocodingLambda && npm install && cd .."
+    "postinstall": "node postinstall.mjs"
   },
   "devDependencies": {
     "@types/jest": "^29.5.5",

--- a/postinstall.mjs
+++ b/postinstall.mjs
@@ -1,0 +1,20 @@
+import { execSync } from "child_process"
+
+const isCI = process.env.CI === "true"
+
+const commands = isCI
+  ? [
+    "cd TiFBackendUtils && npm ci && cd ..",
+    "cd APILambda && npm ci && cd ..",
+    "cd GeocodingLambda && npm ci && cd .."
+  ]
+  : [
+    "cd TiFBackendUtils && npm install && cd ..",
+    "cd APILambda && npm install && cd ..",
+    "cd GeocodingLambda && npm install && cd .."
+  ]
+
+commands.forEach(command => {
+  console.log(command)
+  execSync(command, { stdio: "inherit" })
+})


### PR DESCRIPTION
## Problem/Purpose
npm i postinstall script allows us to install all dependencies for all subprojects, but we should have an npm ci variant for CI.

## Proposed Solution
Make a separate js script to either run "npm i" postinstall script for all subprojects or "npm ci" postinstall script, depending on environment. Then update github actions to use npm ci instead of navigating to each subproject.

## Steps
* Added postinstall.mjs
* Modified package.json to use postinstall.mjs
* Updated github actions to use postinstall

## Results
Running "npm i" from the root folder installs dependencies on all subprojects. 
Running "npm ci" with CI=true in environment installs dependencies on all subprojects in CI mode.
Works on windows and ubuntu.