### PR TITLE
Add env vars to deployment for aiven's db

### DIFF
--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -49,7 +49,12 @@ jobs:
           aws lambda update-function-configuration \
             --function-name lambdaSQLRoute \
             --environment "Variables={\
+              GITHUB_SHA=${{ github.sha }},\
+              ENVIRONMENT=${{ inputs.stage }},\
               DATABASE_HOST=${{ secrets.DATABASE_HOST }},\
+              DATABASE_NAME=${{ inputs.stage }},\
+              DATABASE_PORT=${{ secrets.DATABASE_PORT }},\
+              CA_PEM=${{ secrets.CA_PEM }},\
               DATABASE_USERNAME=$DB_USERNAME,\
               DATABASE_PASSWORD=$DB_PASSWORD,\
               ABLY_KEY=${{ secrets.ABLY_KEY }},\

--- a/.github/workflows/deploy_api.yml
+++ b/.github/workflows/deploy_api.yml
@@ -50,7 +50,6 @@ jobs:
             --function-name lambdaSQLRoute \
             --environment "Variables={\
               GITHUB_SHA=${{ github.sha }},\
-              ENVIRONMENT=${{ inputs.stage }},\
               DATABASE_HOST=${{ secrets.DATABASE_HOST }},\
               DATABASE_NAME=${{ inputs.stage }},\
               DATABASE_PORT=${{ secrets.DATABASE_PORT }},\

--- a/.github/workflows/deploy_geocoder.yml
+++ b/.github/workflows/deploy_geocoder.yml
@@ -47,7 +47,11 @@ jobs:
           aws lambda update-function-configuration \
             --function-name geocodingPipeline \
             --environment "Variables={\
+              GITHUB_SHA=${{ github.sha }},\
               DATABASE_HOST=${{ secrets.DATABASE_HOST }},\
+              DATABASE_NAME=${{ inputs.stage }},\
+              DATABASE_PORT=${{ secrets.DATABASE_PORT }},\
+              CA_PEM=${{ secrets.CA_PEM }},\
               DATABASE_USERNAME=$DB_USERNAME,\
               DATABASE_PASSWORD=$DB_PASSWORD\
             }"

--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -27,6 +27,7 @@ jobs:
     
     env:
       DATABASE_HOST: 127.0.0.1
+      DATABASE_PORT: 3306
       DATABASE_USERNAME: root
       DATABASE_PASSWORD: password
       DATABASE_NAME: tif
@@ -90,7 +91,10 @@ jobs:
     needs: deploy_for_tests
     
     env:
+      CA_PEM: ${{ secrets.CA_PEM }}
       DATABASE_HOST: ${{ secrets.DATABASE_HOST }}
+      DATABASE_PORT: ${{ secrets.DATABASE_PORT }}
+      DATABASE_NAME: stagingTest
       DATABASE_USERNAME: ${{ secrets.DEV_DATABASE_USERNAME }}
       DATABASE_PASSWORD: ${{ secrets.DEV_DATABASE_PASSWORD }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
@@ -98,7 +102,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       ABLY_KEY: ${{ secrets.ABLY_KEY }}
-      AWS_LAMBDA_FUNCTION_NAME: 'lambdaSQLRoute'
+      AWS_LAMBDA_FUNCTION_NAME: lambdaSQLRoute
       COGNITO_CLIENT_APP_ID: ${{ secrets.COGNITO_CLIENT_APP_ID }}
       COGNITO_USER_POOL_ID: ${{ secrets.COGNITO_USER_POOL_ID }}
       SLACK_APP_ID: ${{ secrets.SLACK_APP_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 .env
 .vscode
+*.pem

--- a/APILambda/env.ts
+++ b/APILambda/env.ts
@@ -10,8 +10,11 @@ dotenv.config()
 const EnvSchema = z
   .object({
     DATABASE_HOST: z.string(),
+    DATABASE_PORT: z.string().optional(),
     DATABASE_PASSWORD: z.string(),
     DATABASE_USERNAME: z.string(),
+    DATABASE_NAME: z.string(),
+    CA_PEM: z.string().optional(),
     ABLY_KEY: z.string(),
     AWS_REGION: z.string(),
     AWS_ACCESS_KEY_ID: z.string(),

--- a/TiFBackendUtils/MySQLDriver/dbConnection.ts
+++ b/TiFBackendUtils/MySQLDriver/dbConnection.ts
@@ -9,9 +9,14 @@ dotenv.config()
 const EnvVarsSchema = z
   .object({
     DATABASE_HOST: z.string(),
+    DATABASE_NAME: z.string()
+      .min(1, { message: "Database name must be at least 1 character long." })
+      .max(16, { message: "Database name must be no more than 16 characters long." })
+      .regex(/^[a-zA-Z0-9_]+$/, { message: "Database name must only contain alphanumeric characters and underscores." }),
+    DATABASE_PORT: z.string().optional(),
     DATABASE_PASSWORD: z.string(),
     DATABASE_USERNAME: z.string(),
-    DATABASE_NAME: z.string()
+    CA_PEM: z.string().optional(),
   })
   .passthrough()
 


### PR DESCRIPTION
## Purpose
To use aiven's db, we need the database port and CA certificate to securely connect.

## Proposed Solution
This PR adds those env variables.

## Implementation Steps
Add DATABASE_PORT and CA_PEM env variables to github secrets
Pass those secrets to the test_api, deploy_api and deploy_geocoder scripts
Consume those env variables in api lambda and tifbackendutils package

## Results
This allows the lambda to connect to aiven db on stage.

## Warnings
ca.pem certificate is not needed if you're testing locally (added comment to the tifbackendutils)

## Other Changes
Add github hash to the env variables so when debugging the lambdas, we can confirm they're pointed to the latest commit
Make DATABASE_NAME an env variable rather than a fixed name. Add zod validation to mitigate risk.
Add ca.pem to gitignore
Pass timezone="Z" to mysql connection so all test environments use the same timezone
Also pass decimalNumbers=true to mysql connection so certain mysql types (ex. INT) are automatically converted into numbers

## Follow Ups

https://trello.com/c/V1jk0XT9/641-integrate-new-db-provider-on-stage-and-validate-successful-test-suite