### PR TITLE
Move singleton/lazy initialization of sql connection inside the MySQLDriver

### DIFF
--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -56,7 +56,6 @@ jobs:
         run: |
           npm ci
           cd TiFBackendUtils
-          npm run dbtots
         env:
           CI: true
       
@@ -128,6 +127,10 @@ jobs:
         npm ci
       env:
         CI: true
+
+    - name: Wait for AWS Deployment
+      run: |
+        sleep 15
 
     - name: Authenticate with AWS Cognito and run tests
       run: |

--- a/TiFBackendUtils/MySQLDriver/dbConnection.ts
+++ b/TiFBackendUtils/MySQLDriver/dbConnection.ts
@@ -1,15 +1,16 @@
-import dotenv from "dotenv"
-import mysql from "mysql2/promise.js"
-import { z } from "zod"
-import { MySQLExecutableDriver } from "./MySQLDriver.js"
-export { MySQLExecutableDriver }
+import dotenv from 'dotenv';
+import mysql from "mysql2/promise.js";
+import { z } from 'zod';
 
 dotenv.config()
 
 const EnvVarsSchema = z
   .object({
     DATABASE_HOST: z.string(),
-    DATABASE_NAME: z.string(),
+    DATABASE_NAME: z.string()
+      .min(1, { message: "Database name must be at least 1 character long." })
+      .max(16, { message: "Database name must be no more than 16 characters long." })
+      .regex(/^[a-zA-Z0-9_]+$/, { message: "Database name must only contain alphanumeric characters and underscores." }),
     DATABASE_PORT: z.string().optional(),
     DATABASE_PASSWORD: z.string(),
     DATABASE_USERNAME: z.string(),
@@ -19,49 +20,24 @@ const EnvVarsSchema = z
 
 const envVars = EnvVarsSchema.parse(process.env)
 
-export const recreateDatabase = async () => {
-  const connection = await sqlConn
+export const DATABASE_NAME = envVars.DATABASE_NAME
 
-  try {
-    await connection.changeUser({ database: undefined })
-
-    await connection.query(`DROP DATABASE ${envVars.DATABASE_NAME}`)
-
-    await connection.query(`CREATE DATABASE ${envVars.DATABASE_NAME}`)
-
-    await connection.changeUser({ database: envVars.DATABASE_NAME })
-
-    console.log("Reset the database successfully")
-  } catch (error) {
-    console.error("An error occurred:", error)
-  }
-}
-
-export async function createDatabaseConnection () {
-  try {
-    const connection = await mysql.createConnection({
-      host: envVars.DATABASE_HOST,
-      user: envVars.DATABASE_USERNAME,
-      port: Number(envVars.DATABASE_PORT),
-      password: envVars.DATABASE_PASSWORD,
-      database: envVars.DATABASE_NAME,
-      timezone: 'Z',
-      namedPlaceholders: true,
-      decimalNumbers: true,
-      //if envVars.CA_PEM does not exist, then we're in a local testing env and don't need to pass that to the connection
-      ...(envVars.CA_PEM && {
-        ssl: {
-          ca: envVars.CA_PEM
-        }
-      }),
-    })
-    console.log("Successfully connected to the database.")
-    return connection
-  } catch (error) {
-    console.error("Unable to connect to the database:", error)
-    throw error
-  }
-}
-
-export const sqlConn = createDatabaseConnection()
-export const conn = new MySQLExecutableDriver(sqlConn)
+export const createDatabaseConnection = async (connectionConfig: Partial<mysql.ConnectionOptions> = {}) => {
+  return mysql.createConnection({
+    host: envVars.DATABASE_HOST,
+    user: envVars.DATABASE_USERNAME,
+    port: Number(envVars.DATABASE_PORT),
+    password: envVars.DATABASE_PASSWORD,
+    database: envVars.DATABASE_NAME,
+    timezone: 'Z',
+    namedPlaceholders: true,
+    decimalNumbers: true,
+    //if envVars.CA_PEM does not exist, then we're in a local testing env and don't need to pass that to the connection
+    ...(envVars.CA_PEM && {
+      ssl: {
+        ca: envVars.CA_PEM
+      }
+    }),
+    ...connectionConfig
+  });
+};

--- a/TiFBackendUtils/MySQLDriver/dbConnection.ts
+++ b/TiFBackendUtils/MySQLDriver/dbConnection.ts
@@ -9,10 +9,7 @@ dotenv.config()
 const EnvVarsSchema = z
   .object({
     DATABASE_HOST: z.string(),
-    DATABASE_NAME: z.string()
-      .min(1, { message: "Database name must be at least 1 character long." })
-      .max(16, { message: "Database name must be no more than 16 characters long." })
-      .regex(/^[a-zA-Z0-9_]+$/, { message: "Database name must only contain alphanumeric characters and underscores." }),
+    DATABASE_NAME: z.string(),
     DATABASE_PORT: z.string().optional(),
     DATABASE_PASSWORD: z.string(),
     DATABASE_USERNAME: z.string(),

--- a/TiFBackendUtils/MySQLDriver/index.ts
+++ b/TiFBackendUtils/MySQLDriver/index.ts
@@ -1,0 +1,23 @@
+import { MySQLDriver } from "./MySQLDriver";
+import { DATABASE_NAME, createDatabaseConnection } from "./dbConnection";
+
+export const recreateDatabase = async () => {
+  const connection = await createDatabaseConnection({ database: undefined })
+
+  try {
+    await connection.query(`DROP DATABASE ${DATABASE_NAME}`)
+
+    await connection.query(`CREATE DATABASE ${DATABASE_NAME}`)
+
+    await connection.changeUser({ database: DATABASE_NAME })
+
+    await connection.end()
+
+    console.log("Reset the database successfully")
+  } catch (error) {
+    console.error("An error occurred:", error)
+  }
+}
+
+export type MySQLExecutableDriver = Omit<MySQLDriver, "query" | "execute">
+export const conn: MySQLExecutableDriver = new MySQLDriver();

--- a/TiFBackendUtils/SQLExecutable/tests/MySQLDriver.test.ts
+++ b/TiFBackendUtils/SQLExecutable/tests/MySQLDriver.test.ts
@@ -1,34 +1,32 @@
-import { MySQLExecutableDriver } from "../../MySQLDriver/MySQLDriver.js"
-import { conn, createDatabaseConnection } from "../../MySQLDriver/dbConnection.js"
+import { MySQLDriver } from "../../MySQLDriver/MySQLDriver.js"
 
 export type ExecuteResult = {
   id: string
   rowsAffected: number
 }
 
-describe("MySQLExecutableDriver", () => {
-  let mySQLDriverTest: MySQLExecutableDriver
+describe("MySQLDriver", () => {
+  let mySQLDriverTest: MySQLDriver
 
   beforeAll(async () => {
-    mySQLDriverTest = new MySQLExecutableDriver(createDatabaseConnection())
+    mySQLDriverTest = new MySQLDriver()
     const createMySQLDriverTableSQL = `
     CREATE TABLE IF NOT EXISTS mySQLDriver (
     id bigint NOT NULL,
     name varchar(50) NOT NULL,
     PRIMARY KEY (id)
     )`
-    await conn.transaction(
-      async (tx) => await tx.executeResult(createMySQLDriverTableSQL)
-    )
+    await mySQLDriverTest.execute(createMySQLDriverTableSQL)
   })
 
   afterAll(async () => {
+    await mySQLDriverTest.closeConnection()
     const deleteMySQLDriverTableSQL = `
     DROP TABLE IF EXISTS mySQLDriver
     `
-    await conn.transaction(
-      async (tx) => await tx.executeResult(deleteMySQLDriverTableSQL)
-    )
+    mySQLDriverTest = new MySQLDriver()
+    await mySQLDriverTest.execute(deleteMySQLDriverTableSQL)
+    await mySQLDriverTest.closeConnection()
   })
 
   describe("execute", () => {
@@ -108,7 +106,7 @@ describe("MySQLExecutableDriver", () => {
       await mySQLDriverTest.execute("DELETE FROM mySQLDriver")
       await mySQLDriverTest.closeConnection()
       const query = "INSERT INTO mySQLDriver (name, id) VALUES ('Chungus',1)"
-      await expect(mySQLDriverTest.execute(query)).rejects.toThrow("Can't add new command when connection is in closed state")
+      await expect(mySQLDriverTest.execute(query)).rejects.toThrow("Current connection instance was ended.")
     })
   })
 })

--- a/TiFBackendUtils/database.ts
+++ b/TiFBackendUtils/database.ts
@@ -1,5 +1,5 @@
 import { fail } from "assert"
-import { conn, recreateDatabase } from "./MySQLDriver/dbConnection.js"
+import { conn, recreateDatabase } from "./MySQLDriver/index.js"
 
 const createUserTableSQL = `
 CREATE TABLE IF NOT EXISTS user (

--- a/TiFBackendUtils/dbToTs.ts
+++ b/TiFBackendUtils/dbToTs.ts
@@ -3,9 +3,7 @@ import dotenv from "dotenv"
 import fs from "fs"
 import path from "path"
 import { fileURLToPath } from "url"
-import { conn } from "./MySQLDriver/dbConnection.js"
-// dev use only
-// eslint-disable-next-line import/extensions
+import { conn } from "./MySQLDriver/MySQLDriver.js"
 
 dotenv.config()
 

--- a/TiFBackendUtils/index.ts
+++ b/TiFBackendUtils/index.ts
@@ -1,6 +1,5 @@
 export * from "./AWS/index.js"
-export * from "./MySQLDriver/MySQLDriver.js"
-export * from "./MySQLDriver/dbConnection.js"
+export * from "./MySQLDriver/index.js"
 export * from "./Retryable/utils.js"
 export * from "./TiFUserUtils/index.js"
 export * from "./TifEventUtils.js"


### PR DESCRIPTION
## Problem
Tests fail sometimes on staging.

## Proposed Solution
This could be due to the sql connection becoming invalid when we recreate the database between tests, or due to the sql connection timing out. I'll add a function in the mysql executable to re-connect to the sql db if the current connection is invalid.

## Implementation Steps
Modify the constructor to create a singleton function that either returns the current db connection or a new db connection if the current one is invalid. To check if the current connection is invalid, mysql provides us a .ping() method.

## Results
Staging tests pass consistently, and this also fixes an open handle error in jest

## Other Changes
Add sleep before running staging tests to allow AWS deployment time to settle
Move recreateDatabase out of dbconnection file
Make MySQLExecutableDriver type NOT include the .execute or .query methods

https://trello.com/c/H29w2JOa/695-back-end-fix-flaky-staging-tests