### PR TITLE
Retryable generic

### DIFF
--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -33,6 +33,8 @@ jobs:
       DATABASE_NAME: devTest
       AWS_REGION: ${{ secrets.AWS_REGION }}
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       ABLY_KEY: ${{ secrets.ABLY_KEY }}
       COGNITO_USER_POOL_ID: ${{ secrets.COGNITO_USER_POOL_ID }}
       AWS_LAMBDA_FUNCTION_NAME: lambdaSQLRoute
@@ -107,6 +109,8 @@ jobs:
       DATABASE_PASSWORD: ${{ secrets.DEV_DATABASE_PASSWORD }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       ABLY_KEY: ${{ secrets.ABLY_KEY }}
       AWS_LAMBDA_FUNCTION_NAME: lambdaSQLRoute
       COGNITO_CLIENT_APP_ID: ${{ secrets.COGNITO_CLIENT_APP_ID }}

--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -33,8 +33,6 @@ jobs:
       DATABASE_NAME: devTest
       AWS_REGION: ${{ secrets.AWS_REGION }}
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       ABLY_KEY: ${{ secrets.ABLY_KEY }}
       COGNITO_USER_POOL_ID: ${{ secrets.COGNITO_USER_POOL_ID }}
       AWS_LAMBDA_FUNCTION_NAME: lambdaSQLRoute
@@ -109,8 +107,6 @@ jobs:
       DATABASE_PASSWORD: ${{ secrets.DEV_DATABASE_PASSWORD }}
       AWS_REGION: ${{ secrets.AWS_REGION }}
       AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       ABLY_KEY: ${{ secrets.ABLY_KEY }}
       AWS_LAMBDA_FUNCTION_NAME: lambdaSQLRoute
       COGNITO_CLIENT_APP_ID: ${{ secrets.COGNITO_CLIENT_APP_ID }}

--- a/GeocodingLambda/index.ts
+++ b/GeocodingLambda/index.ts
@@ -6,7 +6,6 @@ import {
   LocationCoordinate2D,
   Placemark,
   Result,
-  Retryable,
   conn,
   exponentialFunctionBackoff,
   promiseResult,
@@ -14,7 +13,7 @@ import {
 } from "TiFBackendUtils"
 import { SearchClosestAddressToCoordinates, addPlacemarkToDB, checkExistingPlacemarkInDB, getTimeZone } from "./utils.js"
 
-interface LocationSearchRequest extends Retryable, LocationCoordinate2D {}
+interface LocationSearchRequest extends LocationCoordinate2D {}
 
 // TODO: Fix handler type, fix util dependencies
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/TiFBackendUtils/AWS/lambdaUtils.ts
+++ b/TiFBackendUtils/AWS/lambdaUtils.ts
@@ -1,5 +1,7 @@
-import { EventBridge } from "@aws-sdk/client-eventbridge"
+import { EventBridge, PutTargetsCommandOutput } from "@aws-sdk/client-eventbridge"
 import { InvocationType, Lambda } from "@aws-sdk/client-lambda"
+import { retryFunction } from "../Retryable/utils.js"
+import { mockInDevTest } from "../mock.js"
 import { AWSEnvVars } from "./env.js"
 
 const eventbridge = new EventBridge({ apiVersion: "2023-04-20" })
@@ -60,3 +62,34 @@ export const deleteEventBridgeRule = async (event: {id: string}) => {
     EventBusName: functionName
   });
 };
+
+/**
+ * Wraps a lambda function to add exponential backoff retry logic.
+ *
+ * @param {function} lambdaFunction The lambda function to wrap. This function should be asynchronous and throw an error if the operation it performs fails.
+ * @param {number} maxRetries The maximum number of retries before the error is rethrown.
+ * @returns {function} A new function that performs the same operation as the original function, but with exponential backoff retries.
+ */
+export const exponentialFunctionBackoff = <T, U>(
+  asyncFn: (event: T) => Promise<PutTargetsCommandOutput | void | U>,
+  maxRetries: number = 3
+) => retryFunction(asyncFn, maxRetries, async (afn, event: T) => {
+  const parsedEvent = typeof event === "string" ? JSON.parse(event) : event;
+  try {
+    await mockInDevTest(deleteEventBridgeRule)(parsedEvent);
+    return await afn(parsedEvent.detail);
+  } catch (e) {
+    console.error(e);
+    const retries = parsedEvent.detail.retries ?? 0;
+    if (retries < maxRetries) {
+      const retryDelay = Math.pow(2, retries);
+      const retryDate = new Date();
+      retryDate.setHours(retryDate.getHours() + retryDelay);
+
+      const newEvent = { ...parsedEvent, detail: { ...parsedEvent.detail, retries: retries + 1 } };
+      return mockInDevTest(scheduleAWSLambda)(retryDate.toISOString(), JSON.stringify(newEvent));
+    } else {
+      throw e;
+    }
+  }
+});

--- a/TiFBackendUtils/AWS/lambdaUtils.ts
+++ b/TiFBackendUtils/AWS/lambdaUtils.ts
@@ -27,11 +27,11 @@ export const scheduleAWSLambda = async (
 ) => {
   const cronExpression = createCronExpressions(dateString)
   const ruleName = `${functionName}_${dateString}`.replace(/[: ]/g, "_")
-  const ruleParams = {
+  await eventbridge.putRule({
     Name: ruleName,
-    ScheduleExpression: cronExpression
-  }
-  await eventbridge.putRule(ruleParams)
+    ScheduleExpression: cronExpression,
+    EventBusName: functionName
+  })
   const targetParams = {
     Rule: ruleName,
     Targets: [
@@ -53,3 +53,10 @@ export const invokeAWSLambda = async (
   InvocationType: InvocationType.RequestResponse,
   Payload: JSON.stringify(targetLambdaParams)
 })
+
+export const deleteEventBridgeRule = async (event: {id: string}) => {
+  await eventbridge.deleteRule({
+    Name: event.id,
+    EventBusName: functionName
+  });
+};

--- a/TiFBackendUtils/Retryable/utils.test.ts
+++ b/TiFBackendUtils/Retryable/utils.test.ts
@@ -1,41 +1,38 @@
-import { exponentialFunctionBackoff } from "./utils.js"
+import { retryFunction } from "./utils.js";
 
-describe("exponentialFunctionBackoff", () => {
-  test("Should not retry if lambda function succeeds", async () => {
-    const successfulLambdaFunction = jest.fn().mockResolvedValue("success")
-    const result = await exponentialFunctionBackoff(
-      successfulLambdaFunction,
-      3
-    )({ retries: 0 })
-    expect(successfulLambdaFunction).toHaveBeenCalledTimes(1)
-    expect(result).toBe("success")
-  })
+describe("retryFunction", () => {
+  test("Should not retry if function succeeds", async () => {
+    const successfulFunction = jest.fn().mockResolvedValue("success");
+    const retriedFunction = retryFunction(successfulFunction, 3);
 
-  test("Should retry up to maxRetries times if lambda function fails", async () => {
-    const failingLambdaFunction = jest
-      .fn()
-      .mockRejectedValue(new Error("failure"))
+    const result = await retriedFunction(undefined);
 
-    let wrappedFunction: (event: unknown) => Promise<unknown> = async () => {} // Placeholder for the wrapped function
+    expect(successfulFunction).toHaveBeenCalledTimes(1);
+    expect(result).toBe("success");
+  });
 
-    const mockScheduleLambda = jest
-      .fn()
-      .mockImplementation((eventTime, event) => {
-        return wrappedFunction(event)
-      })
+  test("Should retry up to maxRetries times if function fails", async () => {
+    const failingFunction = jest.fn().mockRejectedValue(new Error("failure"));
 
-    wrappedFunction = exponentialFunctionBackoff(
-      failingLambdaFunction,
-      2,
-      mockScheduleLambda
-    )
+    const mockRetryFn = jest.fn().mockImplementation(
+      async (asyncFn, event, retriesLeft) => {
+        if (retriesLeft <= 0) {
+          throw new Error("failure");
+        }
+        return retryFunction(asyncFn, retriesLeft - 1, mockRetryFn)(event);
+      }
+    );
+
+    const retriedFunction = retryFunction(failingFunction, 2, mockRetryFn);
 
     try {
-      await wrappedFunction({ retries: 0 })
+      await retriedFunction(undefined);
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
-      expect(failingLambdaFunction).toHaveBeenCalledTimes(3)
-      expect(e.message).toBe("failure")
+      expect(failingFunction).toHaveBeenCalledTimes(3);
+      expect(e.message).toBe("failure");
     }
-  })
-})
+  });
+});

--- a/TiFBackendUtils/Retryable/utils.ts
+++ b/TiFBackendUtils/Retryable/utils.ts
@@ -1,42 +1,27 @@
-import { deleteEventBridgeRule, scheduleAWSLambda } from "../AWS/lambdaUtils.js"
-import { envVars } from "../env.js"
-
-export interface Retryable {
-  retries?: number
-}
-
-/**
- * Wraps a lambda function to add exponential backoff retry logic.
- *
- * @param {function} lambdaFunction The lambda function to wrap. This function should be asynchronous and throw an error if the operation it performs fails.
- * @param {number} maxRetries The maximum number of retries before the error is rethrown.
- * @returns {function} A new function that performs the same operation as the original function, but with exponential backoff retries.
- */
-export const exponentialFunctionBackoff = <T extends Retryable, U>(
-  asyncFunc: (event: T) => Promise<U>,
+export const retryFunction = <T, U>(
+  asyncFn: (event: T) => Promise<U>,
   maxRetries: number = 3,
-  retryAsyncFunc = envVars.ENVIRONMENT === "devTest" ? () => {} : scheduleAWSLambda,
-  cleanup = envVars.ENVIRONMENT === "devTest" ? () => {} : deleteEventBridgeRule
-) => {
-  // retryAsync: (date, T) => U
-  return async (event: T) => {
-    const parsedEvent = typeof event === "string" ? JSON.parse(event) : event // event may be received as a string when triggered with lambda.invoke()?
-    try {
-      await cleanup(parsedEvent)
-      return await asyncFunc(parsedEvent.detail)
-    } catch (e) {
-      console.error(e)
-      const retries = parsedEvent.detail.retries ?? 0
-      if (retries < maxRetries) {
-        const retryDelay = Math.pow(2, retries)
-        const retryDate = new Date()
-        retryDate.setHours(retryDate.getHours() + retryDelay)
-
-        const newEvent = { ...parsedEvent, retries: retries + 1 }
-        return retryAsyncFunc(retryDate.toISOString(), newEvent)
-      } else {
-        throw e
+  retryFn: (asyncFn: (event: T) => Promise<U>, event: T, retriesLeft: number) => Promise<U> 
+    = async (asyncFn, event, retriesLeft) => {
+      for (let attempt = 1; attempt <= retriesLeft; attempt++) {
+        try {
+          return await asyncFn(event);
+        } catch (e) {
+          console.error(`Attempt ${attempt} failed:`, e);
+          if (attempt === retriesLeft) {
+            throw new Error(`Failed after ${retriesLeft} attempts`);
+          }
+        }
       }
+      throw new Error(`Exhausted all retries without success`);
     }
-  }
-}
+): ((event: T) => Promise<U>) => {
+  return async (event: T): Promise<U> => {
+    try {
+      return await asyncFn(event);
+    } catch (e) {
+      console.error(e);
+      return retryFn(asyncFn, event, maxRetries);
+    }
+  };
+};

--- a/TiFBackendUtils/mock.ts
+++ b/TiFBackendUtils/mock.ts
@@ -1,0 +1,6 @@
+import { envVars } from "./env.js";
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const mockInDevTest = (fn: (..._: any) => any) => envVars.ENVIRONMENT === "devTest" ? async () => {} : fn


### PR DESCRIPTION
## Purpose
The eventbridge event bus has room for at max 300 scheduled rules. The event bus was filled because we were creating scheduled rules from local tests, and because we didnt have a mechanism to clear out old eventbridge rules.

## Proposed Solutions
Prevent eventbridge from being called during local tests
Clear eventbridge scheduled events during stage tests
Use different eventbridge event bus for the different lambdas to avoid hitting the 300-event limit
Make the Retryable util more generic so we can test it in local dev without actually hitting eventbridge

## Implementation Steps
Create a new generic retry function that takes in an asyncFunction and another function that serves as the retry mechanism. If asyncFunction fails, the retry mechanism function will be called with the asyncFunction. By default this retry mechanism will simply retry the asyncFunction up to 3 times.
Rewrote tests for this new generic function.
Wrote new wrapper for the retry function to integrate with aws eventbridge.
Added deleteEventBridgeRule util to delete the eventbridge rules created from the lambda.

## Results
Describe the deliverables or results of this PR, which may include screenshots, api responses, or example workflows to help reviewers understand the impact of these changes.

## Other Changes
Made a new util mockInDevTest to easily stub integration functions.

https://trello.com/c/xYE5fpP3/579-tifshared-package-integration-backend