### PR TITLE
fix env vars when creating cognito users

### DIFF
--- a/APILambda/test/createCognitoUsers.ts
+++ b/APILambda/test/createCognitoUsers.ts
@@ -3,7 +3,6 @@ import { AdminConfirmSignUpRequest, AdminUpdateUserAttributesRequest, CognitoIde
 import { fromEnv } from "@aws-sdk/credential-providers"
 import { faker } from "@faker-js/faker"
 import jwt from "jsonwebtoken"
-import { envVars } from "../env"
 import { TestUser, TestUserInput } from "../global"
 import { testEnvVars } from "./testEnv"
 
@@ -34,7 +33,7 @@ export const createCognitoAuthToken = async (
 
   const adminConfirmSignUpParams: AdminConfirmSignUpRequest =
     {
-      UserPoolId: envVars.COGNITO_USER_POOL_ID ?? "",
+      UserPoolId: testEnvVars.COGNITO_USER_POOL_ID ?? "",
       Username: email
     }
 
@@ -42,7 +41,7 @@ export const createCognitoAuthToken = async (
 
   const verifyEmailParams: AdminUpdateUserAttributesRequest =
     {
-      UserPoolId: envVars.COGNITO_USER_POOL_ID ?? "",
+      UserPoolId: testEnvVars.COGNITO_USER_POOL_ID ?? "",
       Username: email,
       UserAttributes: [
         {

--- a/APILambda/test/testEnv.ts
+++ b/APILambda/test/testEnv.ts
@@ -5,7 +5,8 @@ import { z } from "zod"
 const TestEnvSchema = z
   .object({
     API_ENDPOINT: z.string().url().optional(),
-    COGNITO_CLIENT_APP_ID: z.string().optional()
+    COGNITO_CLIENT_APP_ID: z.string().optional(),
+    COGNITO_USER_POOL_ID: z.string().optional()
   }).passthrough()
 
 export const testEnvVars = TestEnvSchema.parse(process.env)


### PR DESCRIPTION
Cant use envVars anymore for testing env when making cognito users. Use testEnv vars instead