### PR TITLE
remove artificial delay for getAttendees tests by allowing milliseconds to be stored in the sql db

### DIFF
--- a/APILambda/events/getAttendees.ts
+++ b/APILambda/events/getAttendees.ts
@@ -70,7 +70,7 @@ const getTiFAttendees = (
     HAVING fromThemToYou IS NULL OR MAX(CASE WHEN ur.toUserId = :userId THEN ur.status END) <> 'blocked' OR ea.role = 'hosting'
     ORDER BY
     CASE WHEN :nextPageUserIdCursor = 'firstPage' THEN CASE WHEN ea.role = 'hosting' THEN 0 ELSE 1 END ELSE 1 END,
-    COALESCE(ua.arrivedDateTime, '9999-12-31 23:59:59.999999') ASC,
+    COALESCE(ua.arrivedDateTime, '9999-12-31 23:59:59.999') ASC,
     ea.joinedDateTime ASC,
     u.id ASC
     LIMIT :limit;

--- a/APILambda/events/getAttendees.ts
+++ b/APILambda/events/getAttendees.ts
@@ -70,7 +70,7 @@ const getTiFAttendees = (
     HAVING fromThemToYou IS NULL OR MAX(CASE WHEN ur.toUserId = :userId THEN ur.status END) <> 'blocked' OR ea.role = 'hosting'
     ORDER BY
     CASE WHEN :nextPageUserIdCursor = 'firstPage' THEN CASE WHEN ea.role = 'hosting' THEN 0 ELSE 1 END ELSE 1 END,
-    COALESCE(ua.arrivedDateTime, '9999-12-31 23:59:59.999') ASC,
+    COALESCE(ua.arrivedDateTime, '9999-12-31 23:59:59.999999') ASC,
     ea.joinedDateTime ASC,
     u.id ASC
     LIMIT :limit;

--- a/APILambda/shared/Cursor.ts
+++ b/APILambda/shared/Cursor.ts
@@ -1,5 +1,3 @@
-const defaultJoinDate = "1970-01-01T00:00:00Z"
-
 /**
  * Encodes the cursor for the attendees list using Buffer.
  *
@@ -11,11 +9,9 @@ export const encodeAttendeesListCursor = ({ userId = "firstPage", joinedDateTime
   joinedDateTime?: Date
   arrivedDateTime?: Date
 }): string => {
-  const joinDateToEncode = joinedDateTime ?? defaultJoinDate
-  const encodedCursor = Buffer.from(
-    `${userId}|${joinDateToEncode}|${arrivedDateTime}`
+  return Buffer.from(
+    `${userId}|${joinedDateTime?.toISOString()}|${arrivedDateTime?.toISOString()}`
   ).toString("base64")
-  return encodedCursor
 }
 
 /**
@@ -27,10 +23,8 @@ export const encodeAttendeesListCursor = ({ userId = "firstPage", joinedDateTime
 export const decodeAttendeesListCursor = (
   cursor: string | undefined
 ): { userId: string; joinedDateTime?: Date; arrivedDateTime?: Date } => {
-  let joinedDateTime = new Date(defaultJoinDate)
-
   if (cursor === undefined) {
-    return { userId: "firstPage", joinedDateTime }
+    return { userId: "firstPage", joinedDateTime: undefined }
   }
 
   const decodedString = Buffer.from(cursor, "base64").toString("utf-8")
@@ -40,8 +34,7 @@ export const decodeAttendeesListCursor = (
   if (decodedUserId === "lastPage") {
     return { userId: "lastPage" }
   }
-  joinedDateTime =
-    decodedJoinDate !== defaultJoinDate ? new Date(decodedJoinDate) : joinedDateTime
+  const joinedDateTime = decodedJoinDate ? new Date(decodedJoinDate) : undefined
   const arrivedDateTime = decodedArrivedDateTime !== "undefined" ? new Date(decodedArrivedDateTime) : undefined
 
   return { userId: decodedUserId, joinedDateTime, arrivedDateTime }

--- a/APILambda/test/userFlows/createEventFlow.ts
+++ b/APILambda/test/userFlows/createEventFlow.ts
@@ -1,5 +1,3 @@
-import { envVars } from "TiFBackendUtils/env"
-import { sleep } from "TiFShared/lib/DelayData"
 import { CreateEventInput } from "../../events/createEvent"
 import { callCreateEvent, callJoinEvent } from "../apiCallers/eventEndpoints"
 import { testEventInput } from "../testEvents"
@@ -39,8 +37,6 @@ export const createEventFlow = async (
     attendeesList.push(attendee)
 
     for (const eventId of eventIds) {
-      // delay needed for test attendees to be properly sorted by join time
-      if (envVars.ENVIRONMENT !== "stagingTest") { await sleep(1000) }
       await callJoinEvent(attendee.token, eventId)
     }
   }

--- a/TiFBackendUtils/MySQLDriver/MySQLDriver.ts
+++ b/TiFBackendUtils/MySQLDriver/MySQLDriver.ts
@@ -16,14 +16,12 @@ const hasInsertionHeader = (result: ResultSetHeader): result is ResultSetHeader 
 const typecasts: Record<number, (value: string | null) => unknown> = {
   3: (value) => value == null ? value : parseInt(value) > 0, // INT or LONG -> BOOLEAN
   1: (value) => value == null ? value : parseInt(value) > 0, // TINYINT -> BOOLEAN
-  7: (value) => value == null ? value : new Date(value), // TIMESTAMP -> DATE
-  12: (value) => value == null ? value : new Date(value), // DATETIME -> DATE
-  246: (value) => value == null ? value : parseFloat(value), // NEWDECIMAL (DECIMAL/NUMERIC) -> NUMBER
+  246: (value) => value == null ? value : parseFloat(value) // NEWDECIMAL (DECIMAL/NUMERIC) -> NUMBER
 }
 
 const castMySQLValues = (rows: RowDataPacket[], fields: FieldPacket[]): RowDataPacket[] => {
   return rows.map(row => {
-    fields.forEach(({name: key, type}) => {
+    fields.forEach(({ name: key, type }) => {
       if (type !== undefined && typecasts[type]) {
         row[key] = typecasts[type](row[key])
       }

--- a/TiFBackendUtils/MySQLDriver/test/tableDefinitions.ts
+++ b/TiFBackendUtils/MySQLDriver/test/tableDefinitions.ts
@@ -5,8 +5,8 @@ export const tableDefintionsByFamily = [
     id char(36) NOT NULL,
     name varchar(50) NOT NULL,
     handle varchar(15) NOT NULL,
-    createdDateTime datetime NOT NULL DEFAULT current_timestamp(),
-    updatedDateTime datetime NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+    createdDateTime datetime(3) NOT NULL DEFAULT current_timestamp(3),
+    updatedDateTime datetime(3) NOT NULL DEFAULT current_timestamp(3) ON UPDATE current_timestamp(3),
     bio varchar(500),
     profileImageURL varchar(200),
     PRIMARY KEY (id),
@@ -20,8 +20,8 @@ export const tableDefintionsByFamily = [
     CREATE TABLE IF NOT EXISTS event (
     id bigint NOT NULL AUTO_INCREMENT,
     description varchar(1000) NOT NULL,
-    startDateTime datetime NOT NULL,
-    endDateTime datetime NOT NULL,
+    startDateTime datetime(3) NOT NULL,
+    endDateTime datetime(3) NOT NULL,
     hostId char(36) NOT NULL,
     color varchar(9) NOT NULL,
     title varchar(100) NOT NULL,
@@ -29,9 +29,9 @@ export const tableDefintionsByFamily = [
     isChatEnabled tinyint(1) NOT NULL,
     latitude decimal(10,7) NOT NULL,
     longitude decimal(10,7) NOT NULL,
-    createdDateTime datetime NOT NULL DEFAULT current_timestamp(),
-    updatedDateTime datetime NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
-    endedDateTime datetime,
+    createdDateTime datetime(3) NOT NULL DEFAULT current_timestamp(3),
+    updatedDateTime datetime(3) NOT NULL DEFAULT current_timestamp(3) ON UPDATE current_timestamp(3),
+    endedDateTime datetime(3),
     PRIMARY KEY (id),
     UNIQUE KEY unique_event_id (id),
     KEY event_host_must_exist (hostId),
@@ -56,7 +56,7 @@ export const tableDefintionsByFamily = [
     CREATE TABLE IF NOT EXISTS eventAttendance (
     userId char(36) NOT NULL,
     eventId bigint NOT NULL,
-    joinedDateTime datetime NOT NULL DEFAULT current_timestamp(),
+    joinedDateTime datetime(3) NOT NULL DEFAULT current_timestamp(3),
     role enum('hosting', 'attending') NOT NULL,
     PRIMARY KEY (userId, eventId),
     KEY event_must_exist (eventId),
@@ -70,7 +70,7 @@ export const tableDefintionsByFamily = [
     userReporting varchar(50) NOT NULL,
     eventReported bigint NOT NULL,
     reportingReason enum('Spam', 'Harassment', 'Hate Speech', 'Violence', 'Scam or fraud', 'Suicide or self-harm', 'False information', 'Sale of illegal or regulated goods', 'Other') NOT NULL,
-    reportDate datetime NOT NULL DEFAULT current_timestamp(),
+    reportDate datetime(3) NOT NULL DEFAULT current_timestamp(3),
     eventOwnerId varchar(36) NOT NULL,
     PRIMARY KEY (userReporting, eventReported)
     )
@@ -88,7 +88,7 @@ export const tableDefintionsByFamily = [
     postalCode varchar(255),
     region varchar(255),
     isoCountryCode varchar(255),
-    createdDateTime datetime NOT NULL DEFAULT current_timestamp(),
+    createdDateTime datetime(3) NOT NULL DEFAULT current_timestamp(3),
     PRIMARY KEY (latitude, longitude)
     )
     `,
@@ -108,7 +108,7 @@ export const tableDefintionsByFamily = [
     userId char(36) NOT NULL,
     latitude decimal(10,7) NOT NULL,
     longitude decimal(10,7) NOT NULL,
-    arrivedDateTime datetime NOT NULL DEFAULT current_timestamp(),
+    arrivedDateTime datetime(3) NOT NULL DEFAULT current_timestamp(3),
     PRIMARY KEY (userId, latitude, longitude),
     KEY sort_by_recent_arrivals (userId, arrivedDateTime),
     CONSTRAINT arriving_user_must_exist FOREIGN KEY (userId) REFERENCES user (id)
@@ -119,7 +119,7 @@ export const tableDefintionsByFamily = [
     `
     CREATE TABLE IF NOT EXISTS userRelations (
     status enum('friends', 'friend-request-pending', 'blocked') NOT NULL,
-    updatedDateTime datetime NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+    updatedDateTime datetime(3) NOT NULL DEFAULT current_timestamp(3) ON UPDATE current_timestamp(3),
     fromUserId char(36) NOT NULL,
     toUserId char(36) NOT NULL,
     PRIMARY KEY (fromUserId, toUserId),
@@ -141,7 +141,7 @@ export const tableDefintionsByFamily = [
       'Sale of illegal or regulated goods', 
       'Other'
     ) NOT NULL,
-    reportDate datetime NOT NULL DEFAULT current_timestamp(),
+    reportDate datetime(3) NOT NULL DEFAULT current_timestamp(3),
     PRIMARY KEY (userReporting, userReported)
     )
     `,
@@ -157,7 +157,7 @@ export const tableDefintionsByFamily = [
     eventPresetPlacemark JSON, 
     eventPresetDurations JSON,
     version bigint NOT NULL DEFAULT '0',
-    updatedDateTime timestamp NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+    updatedDateTime timestamp(3) NULL DEFAULT current_timestamp(3) ON UPDATE current_timestamp(3),
     pushNotificationTriggerIds JSON,
     CHECK (
         JSON_CONTAINS(

--- a/TiFBackendUtils/MySQLDriver/test/tableDefinitions.ts
+++ b/TiFBackendUtils/MySQLDriver/test/tableDefinitions.ts
@@ -1,3 +1,11 @@
+import { envVars } from "../../env"
+
+let timePrecision = 0
+
+if (envVars.ENVIRONMENT === "devTest") {
+  timePrecision = 3 // Avoids needing to add an artificial delay when running attendeesList tests locally
+}
+
 export const tableDefintionsByFamily = [
   [
     `
@@ -5,8 +13,8 @@ export const tableDefintionsByFamily = [
     id char(36) NOT NULL,
     name varchar(50) NOT NULL,
     handle varchar(15) NOT NULL,
-    createdDateTime datetime(3) NOT NULL DEFAULT current_timestamp(3),
-    updatedDateTime datetime(3) NOT NULL DEFAULT current_timestamp(3) ON UPDATE current_timestamp(3),
+    createdDateTime datetime(${timePrecision}) NOT NULL DEFAULT current_timestamp(${timePrecision}),
+    updatedDateTime datetime(${timePrecision}) NOT NULL DEFAULT current_timestamp(${timePrecision}) ON UPDATE current_timestamp(${timePrecision}),
     bio varchar(500),
     profileImageURL varchar(200),
     PRIMARY KEY (id),
@@ -20,8 +28,8 @@ export const tableDefintionsByFamily = [
     CREATE TABLE IF NOT EXISTS event (
     id bigint NOT NULL AUTO_INCREMENT,
     description varchar(1000) NOT NULL,
-    startDateTime datetime(3) NOT NULL,
-    endDateTime datetime(3) NOT NULL,
+    startDateTime datetime(${timePrecision}) NOT NULL,
+    endDateTime datetime(${timePrecision}) NOT NULL,
     hostId char(36) NOT NULL,
     color varchar(9) NOT NULL,
     title varchar(100) NOT NULL,
@@ -29,9 +37,9 @@ export const tableDefintionsByFamily = [
     isChatEnabled tinyint(1) NOT NULL,
     latitude decimal(10,7) NOT NULL,
     longitude decimal(10,7) NOT NULL,
-    createdDateTime datetime(3) NOT NULL DEFAULT current_timestamp(3),
-    updatedDateTime datetime(3) NOT NULL DEFAULT current_timestamp(3) ON UPDATE current_timestamp(3),
-    endedDateTime datetime(3),
+    createdDateTime datetime(${timePrecision}) NOT NULL DEFAULT current_timestamp(${timePrecision}),
+    updatedDateTime datetime(${timePrecision}) NOT NULL DEFAULT current_timestamp(${timePrecision}) ON UPDATE current_timestamp(${timePrecision}),
+    endedDateTime datetime(${timePrecision}),
     PRIMARY KEY (id),
     UNIQUE KEY unique_event_id (id),
     KEY event_host_must_exist (hostId),
@@ -56,7 +64,7 @@ export const tableDefintionsByFamily = [
     CREATE TABLE IF NOT EXISTS eventAttendance (
     userId char(36) NOT NULL,
     eventId bigint NOT NULL,
-    joinedDateTime datetime(3) NOT NULL DEFAULT current_timestamp(3),
+    joinedDateTime datetime(${timePrecision}) NOT NULL DEFAULT current_timestamp(${timePrecision}),
     role enum('hosting', 'attending') NOT NULL,
     PRIMARY KEY (userId, eventId),
     KEY event_must_exist (eventId),
@@ -70,7 +78,7 @@ export const tableDefintionsByFamily = [
     userReporting varchar(50) NOT NULL,
     eventReported bigint NOT NULL,
     reportingReason enum('Spam', 'Harassment', 'Hate Speech', 'Violence', 'Scam or fraud', 'Suicide or self-harm', 'False information', 'Sale of illegal or regulated goods', 'Other') NOT NULL,
-    reportDate datetime(3) NOT NULL DEFAULT current_timestamp(3),
+    reportDate datetime(${timePrecision}) NOT NULL DEFAULT current_timestamp(${timePrecision}),
     eventOwnerId varchar(36) NOT NULL,
     PRIMARY KEY (userReporting, eventReported)
     )
@@ -88,7 +96,7 @@ export const tableDefintionsByFamily = [
     postalCode varchar(255),
     region varchar(255),
     isoCountryCode varchar(255),
-    createdDateTime datetime(3) NOT NULL DEFAULT current_timestamp(3),
+    createdDateTime datetime(${timePrecision}) NOT NULL DEFAULT current_timestamp(${timePrecision}),
     PRIMARY KEY (latitude, longitude)
     )
     `,
@@ -108,7 +116,7 @@ export const tableDefintionsByFamily = [
     userId char(36) NOT NULL,
     latitude decimal(10,7) NOT NULL,
     longitude decimal(10,7) NOT NULL,
-    arrivedDateTime datetime(3) NOT NULL DEFAULT current_timestamp(3),
+    arrivedDateTime datetime(${timePrecision}) NOT NULL DEFAULT current_timestamp(${timePrecision}),
     PRIMARY KEY (userId, latitude, longitude),
     KEY sort_by_recent_arrivals (userId, arrivedDateTime),
     CONSTRAINT arriving_user_must_exist FOREIGN KEY (userId) REFERENCES user (id)
@@ -119,7 +127,7 @@ export const tableDefintionsByFamily = [
     `
     CREATE TABLE IF NOT EXISTS userRelations (
     status enum('friends', 'friend-request-pending', 'blocked') NOT NULL,
-    updatedDateTime datetime(3) NOT NULL DEFAULT current_timestamp(3) ON UPDATE current_timestamp(3),
+    updatedDateTime datetime(${timePrecision}) NOT NULL DEFAULT current_timestamp(${timePrecision}) ON UPDATE current_timestamp(${timePrecision}),
     fromUserId char(36) NOT NULL,
     toUserId char(36) NOT NULL,
     PRIMARY KEY (fromUserId, toUserId),
@@ -141,7 +149,7 @@ export const tableDefintionsByFamily = [
       'Sale of illegal or regulated goods', 
       'Other'
     ) NOT NULL,
-    reportDate datetime(3) NOT NULL DEFAULT current_timestamp(3),
+    reportDate datetime(${timePrecision}) NOT NULL DEFAULT current_timestamp(${timePrecision}),
     PRIMARY KEY (userReporting, userReported)
     )
     `,
@@ -157,7 +165,7 @@ export const tableDefintionsByFamily = [
     eventPresetPlacemark JSON, 
     eventPresetDurations JSON,
     version bigint NOT NULL DEFAULT '0',
-    updatedDateTime timestamp(3) NULL DEFAULT current_timestamp(3) ON UPDATE current_timestamp(3),
+    updatedDateTime timestamp(${timePrecision}) NULL DEFAULT current_timestamp(${timePrecision}) ON UPDATE current_timestamp(${timePrecision}),
     pushNotificationTriggerIds JSON,
     CHECK (
         JSON_CONTAINS(


### PR DESCRIPTION
+ needed to use .isoString in the cursor stringification function since regular .toString() does not store milliseconds

TASK_UNTRACKED