### PR TITLE
Ensure db types is up to date in github action

### DIFF
--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -65,7 +65,12 @@ jobs:
       
       - name: Initialize DB, Update DB Types, Validate openapi specs
         run: |
+          cp TiFBackendUtils/DBTypes.ts OriginalDBTypes.ts
           npm run genapispecs
+          if ! diff TiFBackendUtils/DBTypes.ts OriginalDBTypes.ts; then
+            echo "DBTypes.ts is not up to date. Please re-run 'npm run dbtots' and commit the updated version to this branch."
+            exit 1
+          fi
 
       - name: Run tests
         run: |


### PR DESCRIPTION
The github action will fail if the DB typescript file is not in sync with the DB tables.

Follow up:
Do the same thing for the openapi specs

TASK_UNTRACKED