### PR TITLE
Compile lambdas earlier

### DIFF
--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -7,7 +7,12 @@ on:
       - development
 
 jobs:
+  build:
+    uses: ./.github/workflows/build_api.yml
+    secrets: inherit
+
   test:
+    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 5
     concurrency:
@@ -77,11 +82,6 @@ jobs:
           cd APILambda
           export NODE_OPTIONS="--max_old_space_size=4096"
           npm run test:ci
-
-  build:
-    needs: test
-    uses: ./.github/workflows/build_api.yml
-    secrets: inherit
   
   deploy_for_staging_tests:
     concurrency: 

--- a/.github/workflows/test_geocoder.yml
+++ b/.github/workflows/test_geocoder.yml
@@ -7,7 +7,12 @@ on:
       - development
   
 jobs:
+  build:
+    uses: ./.github/workflows/build_geocoder.yml
+    secrets: inherit
+
   test:
+    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 5
     concurrency:
@@ -64,11 +69,6 @@ jobs:
         run: |
           cd GeocodingLambda
           npm run test:ci
-  
-  build:
-    needs: test
-    uses: ./.github/workflows/build_geocoder.yml
-    secrets: inherit
   
   deploy:
     concurrency: 


### PR DESCRIPTION
## Problem/Purpose
Sometimes our tests pass but there's typescript errors that prevent us from deploying. Not only is this annoying but it also wastes CI time considering the tests take a couple minutes to complete. No use running the tests if the typescript doesn't compile to begin with.

## Proposed Solution
Compile/build the lambdas before running the tests.

TASK_UNTRACKED