### PR TITLE
install tifshared js through env

### DIFF
--- a/.github/workflows/build_api.yml
+++ b/.github/workflows/build_api.yml
@@ -54,6 +54,8 @@ jobs:
           npm ci
           npm install ../TiFBackendUtils/dist/TiFBackendUtils-1.0.0.tgz
           find node_modules/TiFShared -name "*.ts" -type f -delete
+        env:
+          TIFSHARED_JS: true
 
       - name: Build the project
         run: |

--- a/.github/workflows/build_geocoder.yml
+++ b/.github/workflows/build_geocoder.yml
@@ -53,6 +53,8 @@ jobs:
           npm ci
           npm install ../TiFBackendUtils/dist/TiFBackendUtils-1.0.0.tgz
           find node_modules/TiFShared -name "*.ts" -type f -delete
+        env:
+          TIFSHARED_JS: true
       
       - name: Build the project
         run: |


### PR DESCRIPTION
With this pr https://github.com/tifapp/TiFShared/pull/48 the tifshared js was built with every installation. But in local development it proved to be too inconvenient to build the tifshared js each time, as it takes longer, results in extra js files, and when running tests the tifshared imports point to the js files rather than the ts files which are the ones we're editing. Instead I'll make tifshared only compile when an env flag is passed in.

TASK_UNTRACKED