### PR TITLE
Run "test" actions when switching branches for PRs

### DIFF
--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -68,7 +68,7 @@ jobs:
         env:
           CI: true
       
-      - name: Initialize DB, Update DB Types, Validate openapi specs
+      - name: Sync DB with Typescript
         run: |
           cp TiFBackendUtils/DBTypes.ts OriginalDBTypes.ts
           npm run dbtots


### PR DESCRIPTION


Previously the github "test" actions wouldn't trigger if a PR was initially pointed to a different branch, and then switched to target to development. To fix this, added "edited" as a trigger for the "test" github actions.

NVM it causes tests to rerun when editing title or description

TASK_UNTRACKED