### PR TITLE
Script to compare last stable TiFShared version + update TiFShared

### DIFF
--- a/APILambda/package-lock.json
+++ b/APILambda/package-lock.json
@@ -18,7 +18,7 @@
         "jsonwebtoken": "^9.0.2",
         "linkify-it": "^5.0.0",
         "TiFBackendUtils": "file:../TiFBackendUtils",
-        "TiFShared": "github:tifapp/TiFShared#main",
+        "TiFShared": "github:tifapp/TiFShared#b7d9cfa589aecc1f2ef55abf2e26d6635f612744",
         "uuid": "^11.0.2",
         "zod": "^3.22.4"
       },
@@ -109,7 +109,7 @@
         "dayjs": "^1.11.10",
         "dotenv": "^16.3.1",
         "linkify-it": "^5.0.0",
-        "TiFShared": "github:tifapp/TiFShared#main",
+        "TiFShared": "github:tifapp/TiFShared#b7d9cfa589aecc1f2ef55abf2e26d6635f612744",
         "zod": "^3.22.4"
       }
     },

--- a/APILambda/package.json
+++ b/APILambda/package.json
@@ -23,7 +23,7 @@
     "linkify-it": "^5.0.0",
     "TiFBackendUtils": "file:../TiFBackendUtils",
     "uuid": "^11.0.2",
-    "TiFShared": "github:tifapp/TiFShared#b9458d7f5a7a8d6f0a1ebf53677795463fd42b58",
+    "TiFShared": "github:tifapp/TiFShared#b7d9cfa589aecc1f2ef55abf2e26d6635f612744",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/APILambda/package.json
+++ b/APILambda/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "pr": "cd .. && npm run pr",
     "build": "npx tsc --traceResolution --strict false",
-    "test": "npx ts-node node_modules/jest/bin/jest --detectOpenHandles --runInBand",
+    "test": "cd .. && node compareTiFSharedVersion.mjs && cd APILambda && npx ts-node node_modules/jest/bin/jest --detectOpenHandles --runInBand",
     "test:ci": "npx ts-node node_modules/.bin/jest --ci --detectOpenHandles --forceExit --runInBand"
   },
   "keywords": [],
@@ -22,8 +22,8 @@
     "jsonwebtoken": "^9.0.2",
     "linkify-it": "^5.0.0",
     "TiFBackendUtils": "file:../TiFBackendUtils",
-    "TiFShared": "github:tifapp/TiFShared#main",
     "uuid": "^11.0.2",
+    "TiFShared": "github:tifapp/TiFShared#b9458d7f5a7a8d6f0a1ebf53677795463fd42b58",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/GeocodingLambda/package-lock.json
+++ b/GeocodingLambda/package-lock.json
@@ -14,7 +14,7 @@
         "dotenv": "^16.3.1",
         "geo-tz": "^8.0.1",
         "TiFBackendUtils": "file:../TiFBackendUtils",
-        "TiFShared": "github:tifapp/TiFShared#main",
+        "TiFShared": "github:tifapp/TiFShared#b7d9cfa589aecc1f2ef55abf2e26d6635f612744",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -50,7 +50,7 @@
         "dayjs": "^1.11.10",
         "dotenv": "^16.3.1",
         "linkify-it": "^5.0.0",
-        "TiFShared": "github:tifapp/TiFShared#main",
+        "TiFShared": "github:tifapp/TiFShared#b7d9cfa589aecc1f2ef55abf2e26d6635f612744",
         "zod": "^3.22.4"
       }
     },

--- a/GeocodingLambda/package.json
+++ b/GeocodingLambda/package.json
@@ -9,7 +9,7 @@
     "dotenv": "^16.3.1",
     "geo-tz": "^8.0.1",
     "TiFBackendUtils": "file:../TiFBackendUtils",
-    "TiFShared": "github:tifapp/TiFShared#b9458d7f5a7a8d6f0a1ebf53677795463fd42b58",
+    "TiFShared": "github:tifapp/TiFShared#b7d9cfa589aecc1f2ef55abf2e26d6635f612744",
     "zod": "^3.22.4"
   },
   "scripts": {

--- a/GeocodingLambda/package.json
+++ b/GeocodingLambda/package.json
@@ -9,7 +9,7 @@
     "dotenv": "^16.3.1",
     "geo-tz": "^8.0.1",
     "TiFBackendUtils": "file:../TiFBackendUtils",
-    "TiFShared": "github:tifapp/TiFShared#main",
+    "TiFShared": "github:tifapp/TiFShared#b9458d7f5a7a8d6f0a1ebf53677795463fd42b58",
     "zod": "^3.22.4"
   },
   "scripts": {

--- a/TiFBackendUtils/package-lock.json
+++ b/TiFBackendUtils/package-lock.json
@@ -29,7 +29,7 @@
         "dayjs": "^1.11.10",
         "dotenv": "^16.3.1",
         "linkify-it": "^5.0.0",
-        "TiFShared": "github:tifapp/TiFShared#main",
+        "TiFShared": "github:tifapp/TiFShared#b9458d7f5a7a8d6f0a1ebf53677795463fd42b58",
         "zod": "^3.22.4"
       }
     },
@@ -5145,7 +5145,8 @@
     },
     "node_modules/TiFShared": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/tifapp/TiFShared.git#b7d9cfa589aecc1f2ef55abf2e26d6635f612744",
+      "resolved": "git+ssh://git@github.com/tifapp/TiFShared.git#b9458d7f5a7a8d6f0a1ebf53677795463fd42b58",
+      "integrity": "sha512-hLwfSSpcV9sHUiR3C8weLAszSRDNKtCOEolO6mlBShEUxHMdh6T8KJDQHXAZ/+XJ6LXckMY8rKQikkNl9UbbLw==",
       "license": "ISC",
       "peer": true,
       "peerDependencies": {

--- a/TiFBackendUtils/package-lock.json
+++ b/TiFBackendUtils/package-lock.json
@@ -29,7 +29,7 @@
         "dayjs": "^1.11.10",
         "dotenv": "^16.3.1",
         "linkify-it": "^5.0.0",
-        "TiFShared": "github:tifapp/TiFShared#b9458d7f5a7a8d6f0a1ebf53677795463fd42b58",
+        "TiFShared": "github:tifapp/TiFShared#b7d9cfa589aecc1f2ef55abf2e26d6635f612744",
         "zod": "^3.22.4"
       }
     },
@@ -5145,8 +5145,8 @@
     },
     "node_modules/TiFShared": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/tifapp/TiFShared.git#b9458d7f5a7a8d6f0a1ebf53677795463fd42b58",
-      "integrity": "sha512-hLwfSSpcV9sHUiR3C8weLAszSRDNKtCOEolO6mlBShEUxHMdh6T8KJDQHXAZ/+XJ6LXckMY8rKQikkNl9UbbLw==",
+      "resolved": "git+ssh://git@github.com/tifapp/TiFShared.git#b7d9cfa589aecc1f2ef55abf2e26d6635f612744",
+      "integrity": "sha512-yY9zcdYk7ULenVpgg83WhDuHbpJPAC4iJFvYs3tSvibshnvGUS5eeMlUw0T//zoAyYzFBoOLpxraLCij9/aOZQ==",
       "license": "ISC",
       "peer": true,
       "peerDependencies": {

--- a/TiFBackendUtils/package.json
+++ b/TiFBackendUtils/package.json
@@ -13,7 +13,7 @@
     "dayjs": "^1.11.10",
     "dotenv": "^16.3.1",
     "linkify-it": "^5.0.0",
-    "TiFShared": "github:tifapp/TiFShared#b9458d7f5a7a8d6f0a1ebf53677795463fd42b58",
+    "TiFShared": "github:tifapp/TiFShared#b7d9cfa589aecc1f2ef55abf2e26d6635f612744",
     "zod": "^3.22.4"
   },
   "scripts": {

--- a/TiFBackendUtils/package.json
+++ b/TiFBackendUtils/package.json
@@ -13,7 +13,7 @@
     "dayjs": "^1.11.10",
     "dotenv": "^16.3.1",
     "linkify-it": "^5.0.0",
-    "TiFShared": "github:tifapp/TiFShared#main",
+    "TiFShared": "github:tifapp/TiFShared#b9458d7f5a7a8d6f0a1ebf53677795463fd42b58",
     "zod": "^3.22.4"
   },
   "scripts": {

--- a/compareTiFSharedVersion.mjs
+++ b/compareTiFSharedVersion.mjs
@@ -1,0 +1,25 @@
+import { execSync } from "child_process"
+import { readFileSync } from "fs"
+import path from "path"
+
+const getCurrentCommitHash = (repoPath) => {
+  try {
+    return execSync("git rev-parse HEAD", { cwd: repoPath }).toString().trim()
+  } catch (error) {
+    console.error(`Failed to get commit hash for ${repoPath}:`, error)
+    return null
+  }
+}
+
+const packageJson = JSON.parse(readFileSync(path.resolve("TiFBackendUtils/package.json"), "utf8"))
+const expectedCommitHash = packageJson.peerDependencies.TiFShared.split("#")[1]
+
+const currentCommitHash = getCurrentCommitHash(path.resolve("TiFBackendUtils/node_modules/TiFShared"))
+
+if (currentCommitHash !== expectedCommitHash) {
+  console.error(
+    `Linked TiFShared package does not match the expected version; may not work as expected:\nExpected: ${expectedCommitHash}\nFound: ${currentCommitHash}`
+  )
+} else {
+  console.log(`Linked TiFShared package matches the expected version: ${currentCommitHash}`)
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "pr": "ts-node ./TiFBackendUtils/node_modules/TiFShared/npm-scripts/auto-pr",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,md}\"",
     "prepare": "husky",
-    "postinstall": "patch-package && node postinstall.mjs",
+    "postinstall": "patch-package && node postinstall.mjs && node compareTiFSharedVersion.mjs",
+    "test": "node compareTiFSharedVersion.mjs && node test.mjs",
     "dbtots": "npm run resetDB && npx ts-node scripts/dbToTs --run",
     "resetDB": "npx ts-node scripts/resetDB --run"
   },

--- a/test.mjs
+++ b/test.mjs
@@ -1,0 +1,12 @@
+import { execSync } from "child_process"
+
+const commands = [
+  "cd TiFBackendUtils && npm test && cd ..",
+  "cd APILambda && npm test && cd ..",
+  "cd GeocodingLambda && npm test && cd .."
+]
+
+commands.forEach(command => {
+  console.log(command)
+  execSync(command, { stdio: "inherit" })
+})


### PR DESCRIPTION
We'll keep track of the last TiFShared version that successfully passed the tests and give a warning to the dev if their symlinked TiFShared package mismatches.

Shows this message when symlinked TiFShared does not match last stable version
![link2](https://github.com/user-attachments/assets/a7b00144-70d4-4327-b406-9d7602494389)

Shows this message when symlinked TiFShared matches last stable version
![link1](https://github.com/user-attachments/assets/abae2588-74b6-4e89-a35a-b70961349e37)

This also adds some placeholder type fixes to get the project to compile. Will be properly resolved in this pr https://github.com/tifapp/FitnessProjectBackend/pull/276

TASK_UNTRACKED