### PR TITLE
Ban node test

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -40,6 +40,10 @@
             "name": "express",
             "importNames": ["Router"],
             "message": "Use 'ValidatedRouter' instead."
+          },
+          {
+            "name": "node:test",
+            "message": "DELETE THIS NOW. Please use Jest for tests."
           }
         ]
       }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,7 +43,7 @@
           },
           {
             "name": "node:test",
-            "message": "DELETE THIS NOW. Please use Jest for tests."
+            "message": "This import brings grave danger to the world, and the entire tiF universe. Running tests with this import will set off the Pharo Ritual, and the creator god Zucklar will be unleashed upon the world. You will be sent to tiF hell if you continue with this. I recommend using jest for tests, it will save us all.\n\n- Pragma"
           }
         ]
       }


### PR DESCRIPTION
Wasted a few minutes trying to debug test errors only to find we were using the wrong testing library

![image](https://github.com/user-attachments/assets/f724ee07-1d88-49d7-af59-7d75cc65e7de)

https://trello.com/c/CWQWyeoE/845-ban-nodetest-imports