### PR TITLE
Update Upcoming Events to Allow Querying Other User's Event Lists

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,7 @@
     }
   },
   "rules": {
+    "@typescript-eslint/no-namespace": "off",
     "no-restricted-imports": [
       "error",
       {

--- a/APILambda/events/getEventsByRegion.ts
+++ b/APILambda/events/getEventsByRegion.ts
@@ -2,9 +2,9 @@ import { conn } from "TiFBackendUtils"
 import { MySQLExecutableDriver } from "TiFBackendUtils/MySQLDriver"
 import {
   DBTifEvent,
+  UserEventSQL,
   addAttendanceData,
-  tifEventResponseFromDatabaseEvent,
-  userEventsSQL
+  tifEventResponseFromDatabaseEvent
 } from "TiFBackendUtils/TiFEventUtils"
 import { resp } from "TiFShared/api/Transport"
 import { LocationCoordinate2D } from "TiFShared/domain-models/LocationCoordinate2D"
@@ -21,11 +21,18 @@ export const getEventsByRegion = (
     radius: number
   }
 ) => {
-  return conn.queryResult<DBTifEvent>(userEventsSQL("geospatial"), {
-    userLatitude,
-    userLongitude,
-    ...rest
-  })
+  return conn.queryResult<DBTifEvent>(
+    `
+    ${UserEventSQL.BASE}
+    ${UserEventSQL.GEOSPATIAL_WHERE}
+    ${UserEventSQL.ORDER_BY_START_TIME}
+    `,
+    {
+      userLatitude,
+      userLongitude,
+      ...rest
+    }
+  )
 }
 
 export const exploreEvents = authenticatedEndpoint<"exploreEvents">(

--- a/APILambda/events/upcomingEvents.test.ts
+++ b/APILambda/events/upcomingEvents.test.ts
@@ -1,25 +1,35 @@
 import { conn } from "TiFBackendUtils"
 import { dateRange } from "TiFShared/domain-models/FixedDateRange"
-import { LocationCoordinate2D } from "TiFShared/domain-models/LocationCoordinate2D"
-import { dayjs } from "TiFShared/lib/Dayjs"
-import { devEnv } from "../test/devIndex"
-import { addMockLocationToDB } from "../test/location"
+import { addLocationToDB } from "../../GeocodingLambda/utils"
 import { testAPI } from "../test/testApp"
-import { testEventInput } from "../test/testEvents"
+import { testEventInput, testEventInputCoordinate } from "../test/testEvents"
 import { createEventFlow } from "../test/userFlows/createEventFlow"
 import { createUserFlow } from "../test/userFlows/createUserFlow"
 import { createEventTransaction } from "./createEvent"
+import { dayjs } from "TiFShared/lib/Dayjs"
+import { randomUUID } from "crypto"
+import { devEnv } from "../test/devIndex"
 
-const testEventLocation = testEventInput.location.value as LocationCoordinate2D
-
-describe("upcomingEvents tests", () => {
-  beforeEach(() =>
-    addMockLocationToDB(testEventLocation)
-  )
+describe("_upcomingEvents tests", () => {
+  beforeEach(async () => {
+    await addLocationToDB(
+      conn,
+      {
+        ...testEventInputCoordinate,
+        name: "Sample Location",
+        city: "Sample Neighborhood",
+        country: "Sample Country",
+        street: "Sample Street",
+        streetNumber: "1234"
+      },
+      "Sample/Timezone"
+    )
+  })
   test("if no upcoming events, empty", async () => {
     const attendee = await createUserFlow()
     const resp = await testAPI.upcomingEvents<200>({
-      auth: attendee.auth
+      auth: attendee.auth,
+      query: { userId: attendee.id }
     })
     expect(resp.data.events).toEqual([])
   })
@@ -51,12 +61,14 @@ describe("upcomingEvents tests", () => {
       1
     )
     const resp = await testAPI.upcomingEvents<200>({
-      auth: attendee.auth
+      auth: attendee.auth,
+      query: { userId: attendee.id }
     })
     const eventIds = resp.data.events.map((e) => e.id)
     expect(eventIds).toEqual([earliestEventId, middleEventId, latestEventId])
   })
-  test("if past event, removed from list", async () => {
+
+  it("should remove past events from list", async () => {
     const user = await createUserFlow()
     await createEventTransaction(
       conn,
@@ -81,9 +93,94 @@ describe("upcomingEvents tests", () => {
       )
     ).unwrap()
     const resp = await testAPI.upcomingEvents<200>({
-      auth: user.auth
+      auth: user.auth,
+      query: { userId: user.id }
     })
     const eventIds = resp.data.events.map((e) => e.id)
     expect(eventIds).toEqual([upcomingEventId])
+  })
+
+  it("should not load events that the user is not participating in", async () => {
+    const user = await createUserFlow()
+    await createEventFlow(
+      [
+        {
+          dateRange: dateRange(
+            dayjs().add(24, "hour").toDate(),
+            dayjs().add(1, "year").toDate()
+          )
+        },
+        {
+          dateRange: dateRange(
+            dayjs().add(12, "hour").toDate(),
+            dayjs().add(1, "year").toDate()
+          )
+        }
+      ],
+      1
+    )
+    const resp = await testAPI.upcomingEvents<200>({
+      auth: user.auth,
+      query: { userId: user.id }
+    })
+    expect(resp.data.events).toEqual([])
+  })
+
+  it("should load upcoming events for the user with the specified id if a user id is specified", async () => {
+    const user1 = await createUserFlow()
+
+    const {
+      host,
+      eventIds: [eventId]
+    } = await createEventFlow(
+      [
+        {
+          dateRange: dateRange(
+            dayjs().add(24, "hour").toDate(),
+            dayjs().add(1, "year").toDate()
+          )
+        }
+      ],
+      0
+    )
+
+    await testAPI.sendFriendRequest({
+      auth: user1.id,
+      params: { userId: host.id }
+    })
+    const event = await testAPI.eventDetails<200>({
+      auth: user1.auth,
+      params: { eventId }
+    })
+    const resp = await testAPI.upcomingEvents<200>({
+      auth: user1.auth,
+      query: { userId: host.id }
+    })
+    expect(resp.data.events).toEqual([
+      {
+        ...event.data,
+        time: { ...event.data.time, secondsToStart: expect.any(Number) }
+      }
+    ])
+  })
+
+  it("should return user not found when user does not exists", async () => {
+    const user = await createUserFlow()
+    const resp = await testAPI.upcomingEvents<404>({
+      auth: user.auth,
+      query: { userId: randomUUID() }
+    })
+    expect(resp.status).toEqual(404)
+  })
+
+  it("should return blocked when user is blocked by other user", async () => {
+    const user = await createUserFlow()
+    const user2 = await createUserFlow()
+    await testAPI.blockUser({ auth: user2.auth, params: { userId: user.id } })
+    const resp = await testAPI.upcomingEvents<403>({
+      auth: user.auth,
+      query: { userId: user2.id }
+    })
+    expect(resp.status).toEqual(403)
   })
 })

--- a/APILambda/package-lock.json
+++ b/APILambda/package-lock.json
@@ -53,6 +53,7 @@
       "devDependencies": {
         "@asteasolutions/zod-to-openapi": "^6.4.0",
         "@faker-js/faker": "^7.6.0",
+        "@fragaria/address-formatter": "^5.3.0",
         "@ibm-cloud/openapi-ruleset": "^1.15.3",
         "@swc/jest": "^0.2.36",
         "@types/jest": "^29.5.12",
@@ -79,7 +80,6 @@
         "typescript": "^5.4.2"
       },
       "peerDependencies": {
-        "@fragaria/address-formatter": "^5.3.0",
         "dayjs": "^1.11.10",
         "linkify-it": "^5.0.0",
         "zod": "^3.22.4"
@@ -903,6 +903,7 @@
     },
     "../../TiFShared/node_modules/@fragaria/address-formatter": {
       "version": "5.3.0",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -7878,6 +7879,7 @@
     },
     "../../TiFShared/node_modules/mustache": {
       "version": "4.2.0",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "bin": {

--- a/APILambda/router.ts
+++ b/APILambda/router.ts
@@ -18,7 +18,6 @@ import { MatchFnCollection } from "TiFShared/lib/Types/MatchType"
 import { Logger, logger } from "TiFShared/logging"
 import { ServerEnvironment } from "./env"
 import { catchAPIErrors } from "./errorHandler"
-import { ZodObject } from "zod"
 
 export type RequestContext = {
   selfId: UserID

--- a/APILambda/router.ts
+++ b/APILambda/router.ts
@@ -1,10 +1,15 @@
 import express from "express"
 import { IncomingHttpHeaders } from "http"
-import { TiFAPIClient, TiFAPISchema, validateAPIRouterCall } from "TiFBackendUtils"
+import {
+  TiFAPIClient,
+  TiFAPISchema,
+  validateAPIRouterCall
+} from "TiFBackendUtils"
 import {
   APIHandler,
   APIMiddleware,
-  APISchema, GenericEndpointSchema
+  APISchema,
+  GenericEndpointSchema
 } from "TiFShared/api/TransportTypes"
 import { UserID } from "TiFShared/domain-models/User"
 import { chainMiddleware, middlewareRunner } from "TiFShared/lib/Middleware"
@@ -13,6 +18,7 @@ import { MatchFnCollection } from "TiFShared/lib/Types/MatchType"
 import { Logger, logger } from "TiFShared/logging"
 import { ServerEnvironment } from "./env"
 import { catchAPIErrors } from "./errorHandler"
+import { ZodObject } from "zod"
 
 export type RequestContext = {
   selfId: UserID

--- a/APILambda/test/devIndex.ts
+++ b/APILambda/test/devIndex.ts
@@ -8,6 +8,7 @@ import { addTiFRouter, createApp } from "../appMiddleware"
 import { ServerEnvironment } from "../env"
 import { mockLocationCoordinate2D } from "./testEvents"
 import { geocodeMock } from "./location"
+import { localhostListener } from "./localhostListener"
 
 export const devEnv: ServerEnvironment = {
   environment: "devTest",
@@ -24,4 +25,8 @@ export const devEnv: ServerEnvironment = {
   }
 }
 
-export const devApp = createApp(devEnv, addTiFRouter)
+const middlewares = [addTiFRouter]
+if (process.env.NODE_ENV !== "test") {
+  middlewares.push(localhostListener)
+}
+export const devApp = createApp(devEnv, ...middlewares)

--- a/APILambda/test/devIndex.ts
+++ b/APILambda/test/devIndex.ts
@@ -6,7 +6,6 @@ import { promiseResult, success } from "TiFShared/lib/Result"
 import { handler } from "../../GeocodingLambda/index"
 import { addTiFRouter, createApp } from "../appMiddleware"
 import { ServerEnvironment } from "../env"
-import { localhostListener } from "./localhostListener"
 import { mockLocationCoordinate2D } from "./testEvents"
 import { geocodeMock } from "./location"
 
@@ -16,15 +15,13 @@ export const devEnv: ServerEnvironment = {
   eventStartWindowInHours: 1,
   geocode: (location) => {
     return promiseResult(
-      handler(
-        location,
-        geocodeMock,
-        async () => mockLocationCoordinate2D()
-      ).then(response => {
+      handler(location, geocodeMock, async () =>
+        mockLocationCoordinate2D()
+      ).then((response) => {
         return success(response)
       })
     )
   }
 }
 
-export const devApp = createApp(devEnv, addTiFRouter, localhostListener)
+export const devApp = createApp(devEnv, addTiFRouter)

--- a/APILambda/test/testEvents.ts
+++ b/APILambda/test/testEvents.ts
@@ -5,6 +5,7 @@ import {
 } from "TiFBackendUtils/test/dateHelpers"
 import { EventEdit } from "TiFShared/domain-models/Event"
 import { dateRange } from "TiFShared/domain-models/FixedDateRange"
+import { LocationCoordinate2D } from "TiFShared/domain-models/LocationCoordinate2D"
 import { dayjs } from "TiFShared/lib/Dayjs"
 
 // Coords in the US mainland
@@ -28,6 +29,9 @@ const createTestEvent = (): EventEdit => ({
 export const testEventCoordinate = { latitude: 50, longitude: 50 }
 
 export const testEventInput = createTestEvent()
+
+export const testEventInputCoordinate = testEventInput.location
+  .value as LocationCoordinate2D
 
 // reason: milliseconds are not counted in the live database
 export const upcomingEventDateRange = dateRange(

--- a/TiFBackendUtils/TiFEventUtils/EventAttendance.ts
+++ b/TiFBackendUtils/TiFEventUtils/EventAttendance.ts
@@ -128,12 +128,14 @@ const addAttendance = (
       }
     ])
   )
-  attendees.forEach(({ attendee, eventId }: {attendee: Attendee, eventId: EventID}) => {
-    const event = map.get(eventId)
-    if (!event) return
-    event.previewAttendees.push(attendee)
-    event.attendeeCount++
-  })
+  attendees.forEach(
+    ({ attendee, eventId }: { attendee: Attendee; eventId: EventID }) => {
+      const event = map.get(eventId)
+      if (!event) return
+      event.previewAttendees.push(attendee)
+      event.attendeeCount++
+    }
+  )
   userAttendances.forEach(({ eventId, ...attendance }) => {
     const event = map.get(eventId)
     if (!event) return

--- a/TiFBackendUtils/TiFEventUtils/EventDetails.ts
+++ b/TiFBackendUtils/TiFEventUtils/EventDetails.ts
@@ -1,7 +1,7 @@
 import { failure, success } from "TiFShared/lib/Result"
 import { MySQLExecutableDriver } from "../MySQLDriver"
 import { DBTifEvent } from "./TiFEventResponse"
-import { USER_EVENT_SQL } from "./UserEvent"
+import { UserEventSQL } from "./UserEvent"
 
 export const getEventSQL = (
   conn: MySQLExecutableDriver,
@@ -11,9 +11,9 @@ export const getEventSQL = (
   conn
     .queryFirstResult<DBTifEvent>(
       `
-      ${USER_EVENT_SQL}
+      ${UserEventSQL.BASE}
       WHERE TifEventView.id = :eventId;
-  `,
+      `,
       { eventId, userId }
     )
     .withFailure({ error: "event-not-found" as const })

--- a/TiFBackendUtils/TiFUserUtils/TiFUserResponse.ts
+++ b/TiFBackendUtils/TiFUserUtils/TiFUserResponse.ts
@@ -2,10 +2,41 @@ import { ExtractSuccess, failure, success } from "TiFShared/lib/Result"
 import { DBuser } from "../DBTypes"
 import { MySQLExecutableDriver } from "../MySQLDriver/index"
 import {
-    UserRelations,
-    UserRelationshipPair,
-    UserRelationsSchema
+  UserRelations,
+  UserRelationshipPair,
+  UserRelationsSchema
 } from "./UserRelationships"
+
+const FIND_USER_SQL = `
+  CASE WHEN :fromUserId = :toUserId
+    THEN 'current-user'
+    ELSE COALESCE(fromThemToYou.status, 'not-friends')
+  END AS fromThemToYou,
+  CASE WHEN :fromUserId = :toUserId
+    THEN 'current-user'
+    ELSE COALESCE(fromYouToThem.status, 'not-friends')
+  END AS fromYouToThem
+FROM
+    user theirUser
+    LEFT JOIN userRelationships fromThemToYou ON fromThemToYou.fromUserId = theirUser.id AND fromThemToYou.toUserId = :fromUserId
+    LEFT JOIN userRelationships fromYouToThem ON fromYouToThem.fromUserId = :fromUserId AND fromYouToThem.toUserId = theirUser.id
+WHERE theirUser.id = :toUserId;`
+
+export const userRelations = (
+  conn: MySQLExecutableDriver,
+  { fromUserId, toUserId }: UserRelationshipPair
+) =>
+  conn
+    .queryFirstResult<DBuser & UserRelations>(
+      `
+      SELECT
+        ${FIND_USER_SQL}
+      `,
+      { fromUserId, toUserId }
+    )
+    .flatMapSuccess(({ fromThemToYou, fromYouToThem }) => {
+      return userRelationsStatus(fromThemToYou, fromYouToThem)
+    })
 
 export const findTiFUser = (
   conn: MySQLExecutableDriver,
@@ -15,34 +46,25 @@ export const findTiFUser = (
     .queryFirstResult<DBuser & UserRelations>(
       `
       SELECT
-      theirUser.*,
-          CASE
-            WHEN :fromUserId = :toUserId THEN 'current-user'
-            ELSE COALESCE(fromThemToYou.status, 'not-friends')
-          END AS fromThemToYou,
-          CASE
-            WHEN :fromUserId = :toUserId THEN 'current-user'
-            ELSE COALESCE(fromYouToThem.status, 'not-friends')
-          END AS fromYouToThem
-      FROM
-          user theirUser
-          LEFT JOIN userRelationships fromThemToYou ON fromThemToYou.fromUserId = theirUser.id AND fromThemToYou.toUserId = :fromUserId
-          LEFT JOIN userRelationships fromYouToThem ON fromYouToThem.fromUserId = :fromUserId AND fromYouToThem.toUserId = theirUser.id
-      WHERE theirUser.id = :toUserId;
+        theirUser.*,
+        ${FIND_USER_SQL}
       `,
       { fromUserId, toUserId }
     )
     .flatMapSuccess(({ fromThemToYou, fromYouToThem, ...user }) => {
-      const relationStatus = UserRelationsSchema.parse({
-        fromThemToYou,
-        fromYouToThem
-      })
-
-      if (relationStatus === "blocked-you") {
-        return failure({ ...user, relationStatus })
-      } else {
-        return success({ ...user, relationStatus })
-      }
+      return userRelationsStatus(fromThemToYou, fromYouToThem)
+        .mapSuccess((relationStatus) => ({ ...user, relationStatus }))
+        .mapFailure((relationStatus) => ({ ...user, relationStatus }))
     })
+
+const userRelationsStatus = (fromThemToYou: string, fromYouToThem: string) => {
+  const relationStatus = UserRelationsSchema.parse({
+    fromThemToYou,
+    fromYouToThem
+  })
+  return relationStatus === "blocked-you"
+    ? failure(relationStatus)
+    : success(relationStatus)
+}
 
 export type TiFUser = ExtractSuccess<ReturnType<typeof findTiFUser>>


### PR DESCRIPTION
The frontend needs to display the upcoming events for any given user on the platform on their profile screen. Therefore, I added a `userId` query parameter to the upcoming events endpoint to enable the functionality. The endpoint can also now return 404s and 403s if the user is not found, or is blocking the requesting user.

I also cleaned up the reusable user event SQL into a namespace called `UserEventSQL` that just contains static SQL statements that can be interpolated into queries. Before, we had a function that would accept a filter string which would be used to build the query, but that started to become an abuse of DRY. I found it was much simpler to just append the static SQL strings together depending on the query.

## Tickets

https://trello.com/c/LBehUsWt
