### PR TITLE
add error catching to lambdas

### DIFF
--- a/APILambda/events/createEvent.test.ts
+++ b/APILambda/events/createEvent.test.ts
@@ -1,4 +1,6 @@
 import { dayjs } from "TiFShared/lib/Dayjs"
+import { handler } from "../../GeocodingLambda/handler"
+import { overrideDevEnv } from "../test/devIndex"
 import { addMockLocationToDB } from "../test/location"
 import { testAPI } from "../test/testApp"
 import { testEventInput } from "../test/testEvents"
@@ -6,7 +8,12 @@ import { createEventFlow } from "../test/userFlows/createEventFlow"
 import { createUserFlow } from "../test/userFlows/createUserFlow"
 
 describe("CreateEvent tests", () => {
+  // integration test, should skip or modify for local tests
   it("should allow a user to create an event and add them to the attendee list", async () => {
+    overrideDevEnv({
+      geocode: handler
+    })
+
     const startDateTime = dayjs(new Date()).millisecond(0).toDate().ext.addSeconds(10)
     const {
       host,
@@ -14,7 +21,14 @@ describe("CreateEvent tests", () => {
     } = await createEventFlow([
       {
         startDateTime,
-        duration: 3600
+        duration: 3600,
+        location: {
+          type: "coordinate",
+          value: {
+            latitude: 36.99813840222285,
+            longitude: -122.05564377465653
+          }
+        }
       }
     ])
 
@@ -46,6 +60,55 @@ describe("CreateEvent tests", () => {
               .toDate()
               .toISOString()
           }
+        },
+        location: {
+          placemark: {
+            city: "Westside",
+            isoCountryCode: "USA",
+            name: "420 Hagar Dr, Santa Cruz, CA 95064, United States",
+            postalCode: "95064",
+            street: "Hagar Dr",
+            streetNumber: "420"
+          },
+          timezoneIdentifier: "America/Los_Angeles"
+        }
+      }
+    })
+  })
+
+  it("should allow a user to create an event with a placemark", async () => {
+    overrideDevEnv({
+      geocode: handler
+    })
+
+    const {
+      eventResponses: [event]
+    } = await createEventFlow([
+      {
+        location: {
+          type: "placemark",
+          value: {
+            city: "Westside",
+            isoCountryCode: "USA",
+            name: "420 Hagar Dr, Santa Cruz, CA 95064, United States",
+            postalCode: "95064",
+            street: "Hagar Dr",
+            streetNumber: "420"
+          }
+        }
+      }
+    ])
+
+    expect(event).toMatchObject({
+      status: 201,
+      data: {
+        id: expect.any(Number),
+        location: {
+          coordinate: {
+            latitude: expect.closeTo(36.9981),
+            longitude: expect.closeTo(-122.0556)
+          },
+          timezoneIdentifier: "America/Los_Angeles"
         }
       }
     })

--- a/APILambda/index.ts
+++ b/APILambda/index.ts
@@ -1,7 +1,14 @@
 try {
   const { handler } = require("./app")
-  exports.handler = handler
+  exports.handler = async (...rest: unknown[]) => {
+    try {
+      return handler(...rest)
+    } catch (error: unknown) {
+      console.error("Execution error:", error)
+      throw error
+    }
+  }
 } catch (error) {
-  console.error("Lambda error:", error.stack || error.message)
+  console.error("Import error:", error)
   throw error
 }

--- a/APILambda/test/devIndex.ts
+++ b/APILambda/test/devIndex.ts
@@ -2,26 +2,36 @@ import "TiFBackendUtils"
 import "TiFShared/lib/Zod"
 // Only used in local tests
 
-import { promiseResult, success } from "TiFShared/lib/Result"
-import { handler } from "../../GeocodingLambda/index"
+import { handler } from "../../GeocodingLambda/handler"
 import { addTiFRouter, createApp } from "../appMiddleware"
 import { ServerEnvironment } from "../env"
-import { mockLocationCoordinate2D } from "./testEvents"
-import { geocodeMock } from "./location"
 import { localhostListener } from "./localhostListener"
+import { geocodeMock } from "./location"
+import { mockLocationCoordinate2D } from "./testEvents"
 
 export const devEnv: ServerEnvironment = {
   environment: "devTest",
   maxArrivals: 4,
   eventStartWindowInHours: 1,
   geocode: (location) => {
-    return promiseResult(
-      handler(location, geocodeMock, async () =>
-        mockLocationCoordinate2D()
-      ).then((response) => {
-        return success(response)
-      })
-    )
+    return handler(location, geocodeMock, async () => mockLocationCoordinate2D())
+  }
+}
+
+let originalDevEnv: ServerEnvironment | null = null
+
+export const overrideDevEnv = (partialDevEnv: Partial<ServerEnvironment>) => {
+  if (!originalDevEnv) {
+    originalDevEnv = { ...devEnv }
+  }
+
+  Object.assign(devEnv, partialDevEnv)
+}
+
+export const restoreDevEnv = () => {
+  if (originalDevEnv) {
+    Object.assign(devEnv, originalDevEnv)
+    originalDevEnv = null
   }
 }
 

--- a/APILambda/test/jest/setupHooksAfterEnv.ts
+++ b/APILambda/test/jest/setupHooksAfterEnv.ts
@@ -2,6 +2,7 @@ import { conn } from "TiFBackendUtils"
 import { resetDB } from "TiFBackendUtils/test/MySQLDriver/dbHelpers"
 import { addLogHandler, consoleLogHandler } from "TiFShared/logging"
 import { closeLocalhostServer } from "../localhostListener"
+import { restoreDevEnv } from "../devIndex"
 
 global.beforeAll(() =>
   addLogHandler(consoleLogHandler())
@@ -14,6 +15,9 @@ global.beforeEach(async () => {
   await resetDB()
 })
 
-global.afterEach(closeLocalhostServer)
+global.afterEach(() => {
+  restoreDevEnv()
+  return closeLocalhostServer()
+})
 
 global.afterAll(() => conn.closeConnection())

--- a/APILambda/test/userFlows/createEventFlow.ts
+++ b/APILambda/test/userFlows/createEventFlow.ts
@@ -26,6 +26,10 @@ export const createEventFlow = async (
 
   const eventResponses = await Promise.all(
     eventInputs.map((details) => {
+      console.log("creating an event")
+      console.log(host.auth)
+      console.log(testEventEdit(details))
+
       return testAPI.createEvent({
         auth: host.auth,
         body: testEventEdit(details)

--- a/GeocodingLambda/handler.ts
+++ b/GeocodingLambda/handler.ts
@@ -6,7 +6,7 @@ import { EventEditLocation } from "TiFShared/domain-models/Event"
 import { LocationCoordinate2D } from "TiFShared/domain-models/LocationCoordinate2D"
 import { Placemark } from "TiFShared/domain-models/Placemark"
 import { promiseResult, success } from "TiFShared/lib/Result"
-import { logger } from "TiFShared/logging"
+import { addLogHandler, consoleLogHandler, logger } from "TiFShared/logging"
 import {
   addLocationToDB,
   checkExistingPlacemarkInDB,
@@ -15,6 +15,8 @@ import {
   SearchClosestAddressToCoordinatesAWS,
   SearchCoordinatesForAddressAWS
 } from "./utils"
+
+addLogHandler(consoleLogHandler())
 
 const log = logger("tif.backend.geocoder")
 

--- a/GeocodingLambda/handler.ts
+++ b/GeocodingLambda/handler.ts
@@ -26,6 +26,9 @@ export const handler = (
   forwardGeocodeHandler?: (placemark: Placemark) => Promise<LocationCoordinate2D>
 ) => {
   log.info("Geocoding request: ", { locationEdit })
+  console.log("geocode handlers")
+  console.log(reverseGeocodeHandler)
+  console.log(forwardGeocodeHandler)
 
   // NB: cannot pass functions in aws environment, so perform the parameterization inside
   const reverseGeocode = typeof reverseGeocodeHandler === "function" ? reverseGeocodeHandler : SearchClosestAddressToCoordinatesAWS
@@ -69,5 +72,4 @@ export const handler = (
           ))
         })
     )
-    .unwrap()
 }

--- a/GeocodingLambda/index.ts
+++ b/GeocodingLambda/index.ts
@@ -1,11 +1,16 @@
-exports.handler = async (event: any, context: any) => {
-  console.log("Log Stream Name:", context.logStreamName)
-  console.log("Event:", JSON.stringify(event))
-  try {
-    const { handler } = require("./handler")
-    return (await handler(event, context)).unwrap()
-  } catch (error) {
-    console.error("Execution error:", error)
-    throw error
+import type { EventEditLocation } from "TiFShared/domain-models/Event"
+
+try {
+  const { handler } = require("./handler")
+  exports.handler = async (params: EventEditLocation) => {
+    try {
+      return (await handler(params)).unwrap()
+    } catch (error: unknown) {
+      console.error("Execution error:", error)
+      throw error
+    }
   }
+} catch (error) {
+  console.error("Import error:", error)
+  throw error
 }

--- a/GeocodingLambda/index.ts
+++ b/GeocodingLambda/index.ts
@@ -1,8 +1,14 @@
 try {
   const { handler } = require("./handler")
-  exports.handler = handler
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-} catch (error: any) {
-  console.error("Lambda error:", error.stack || error.message)
+  exports.handler = async (...rest: unknown[]) => {
+    try {
+      return handler(...rest)
+    } catch (error: unknown) {
+      console.error("Execution error:", error)
+      throw error
+    }
+  }
+} catch (error) {
+  console.error("Import error:", error)
   throw error
 }

--- a/GeocodingLambda/index.ts
+++ b/GeocodingLambda/index.ts
@@ -1,14 +1,11 @@
-try {
-  const { handler } = require("./handler")
-  exports.handler = async (...rest: unknown[]) => {
-    try {
-      return (await handler(...rest)).unwrap()
-    } catch (error: unknown) {
-      console.error("Execution error:", error)
-      throw error
-    }
+exports.handler = async (event: any, context: any) => {
+  console.log("Log Stream Name:", context.logStreamName)
+  console.log("Event:", JSON.stringify(event))
+  try {
+    const { handler } = require("./handler")
+    return (await handler(event, context)).unwrap()
+  } catch (error) {
+    console.error("Execution error:", error)
+    throw error
   }
-} catch (error) {
-  console.error("Import error:", error)
-  throw error
 }

--- a/GeocodingLambda/index.ts
+++ b/GeocodingLambda/index.ts
@@ -2,7 +2,7 @@ try {
   const { handler } = require("./handler")
   exports.handler = async (...rest: unknown[]) => {
     try {
-      return handler(...rest)
+      return (await handler(...rest)).unwrap()
     } catch (error: unknown) {
       console.error("Execution error:", error)
       throw error

--- a/GeocodingLambda/integration.test.ts
+++ b/GeocodingLambda/integration.test.ts
@@ -154,7 +154,7 @@ describe("Geocoding lambda tests", () => {
     it.each(testLocations)(
       "Should find the coordinates and save a placemark given the address of $name",
       async ({ placemark, coordinate }) => {
-        const result = await handler(placemark)
+        const result = (await handler(placemark)).unwrap()
 
         expect(result).toMatchObject({
           coordinate: {
@@ -166,7 +166,7 @@ describe("Geocoding lambda tests", () => {
           )
         })
 
-        const cachedResult = await handler(placemark, mockGeocoding, mockReverseGeocoding)
+        const cachedResult = (await handler(placemark, mockGeocoding, mockReverseGeocoding)).unwrap()
         expect(mockGeocoding).toHaveBeenCalledTimes(0)
         expect(mockReverseGeocoding).toHaveBeenCalledTimes(0)
 
@@ -183,7 +183,7 @@ describe("Geocoding lambda tests", () => {
     )
 
     it("Should use default coordinates given an unknown address", async () => {
-      const result = await handler(unknownAddressTestLocation.placemark)
+      const result = (await handler(unknownAddressTestLocation.placemark)).unwrap()
 
       expect(result).toMatchObject({
         coordinate: {
@@ -200,7 +200,7 @@ describe("Geocoding lambda tests", () => {
     it.each(testLocations)(
       "Should find the address and save a placemark given the coordinates of $name",
       async ({ coordinate, placemark }) => {
-        const result = await handler(coordinate)
+        const result = (await handler(coordinate)).unwrap()
 
         expect(result).toMatchObject({
           coordinate: {
@@ -212,7 +212,7 @@ describe("Geocoding lambda tests", () => {
           )
         })
 
-        const cachedResult = await handler(coordinate, mockGeocoding, mockReverseGeocoding)
+        const cachedResult = (await handler(coordinate, mockGeocoding, mockReverseGeocoding)).unwrap()
         expect(mockGeocoding).toHaveBeenCalledTimes(0)
         expect(mockReverseGeocoding).toHaveBeenCalledTimes(0)
 
@@ -229,7 +229,7 @@ describe("Geocoding lambda tests", () => {
     )
 
     it("Should use default address given unknown coordinates", async () => {
-      const result = await handler(unknownAddressTestLocation.coordinate)
+      const result = (await handler(unknownAddressTestLocation.coordinate)).unwrap()
 
       expect(result).toMatchObject({
         coordinate: {


### PR DESCRIPTION
Currently lambda invoke errors look vague in aws logs:
![image](https://github.com/user-attachments/assets/65a01af3-0980-4111-b205-bf8b1d5cd695)
![image](https://github.com/user-attachments/assets/4619f257-ca40-4f28-88f7-5cc7e6f04aa6)

This pr makes errors more descriptive in aws logging