### PR TITLE
Fixed geocoding matching function

### DIFF
--- a/APILambda/events/createEvent.test.ts
+++ b/APILambda/events/createEvent.test.ts
@@ -1,3 +1,4 @@
+import { conn } from "TiFBackendUtils"
 import { dayjs } from "TiFShared/lib/Dayjs"
 import { handler } from "../../GeocodingLambda/handler"
 import { overrideDevEnv } from "../test/devIndex"
@@ -99,6 +100,16 @@ describe("CreateEvent tests", () => {
       }
     ])
 
+    const { value: locations } = await conn.queryResult("SELECT * FROM location;")
+
+    console.log("current locations are")
+    console.log(locations)
+
+    const { value } = await conn.queryResult("SELECT * FROM TifEventView;")
+
+    console.log("current events are")
+    console.log(value)
+
     expect(event).toMatchObject({
       status: 201,
       data: {
@@ -129,6 +140,17 @@ describe("CreateEvent tests", () => {
         }
       }
     ])
+
+    const { value: locations } = await conn.queryResult("SELECT * FROM location;")
+
+    console.log("current locations are")
+    console.log(locations)
+
+    const { value } = await conn.queryResult("SELECT * FROM TifEventView;")
+
+    console.log("current events are")
+    console.log(value)
+
     const resp = await testAPI.eventDetails({
       auth: newUser.auth,
       params: { eventId: eventIds[0] }

--- a/GeocodingLambda/handler.ts
+++ b/GeocodingLambda/handler.ts
@@ -28,9 +28,6 @@ export const handler = (
   forwardGeocodeHandler?: (placemark: Placemark) => Promise<LocationCoordinate2D>
 ) => {
   log.info("Geocoding request: ", { locationEdit })
-  console.log("geocode handlers")
-  console.log(reverseGeocodeHandler)
-  console.log(forwardGeocodeHandler)
 
   // NB: cannot pass functions in aws environment, so perform the parameterization inside
   const reverseGeocode = typeof reverseGeocodeHandler === "function" ? reverseGeocodeHandler : SearchClosestAddressToCoordinatesAWS

--- a/GeocodingLambda/integration.test.ts
+++ b/GeocodingLambda/integration.test.ts
@@ -114,10 +114,10 @@ export const testLocations: TestLocation[] = [
       value: {
         city: "Westminster",
         isoCountryCode: "GBR",
-        name: "Big Ben, Victoria Embankment, London, SW1A 2, United Kingdom",
-        postalCode: "SW1A 2",
+        name: "Big Ben (Elizabeth Tower), Parliament Square, London, SW1A 0AA, United Kingdom",
+        postalCode: "SW1A 0AA",
         region: "England",
-        street: "Victoria Embankment"
+        street: "Parliament Square"
       }
     }
   },

--- a/GeocodingLambda/integration.test.ts
+++ b/GeocodingLambda/integration.test.ts
@@ -9,28 +9,53 @@ interface TestLocation {
   placemark: Extract<EventEditLocation, { type?: "placemark" }>
 }
 
-export const testLocations: TestLocation[] = [
-  {
-    name: "Santa Cruz (West Coast US)",
-    coordinate: {
-      type: "coordinate",
-      value: {
-        latitude: 36.99813840222285,
-        longitude: -122.05564377465653
-      }
-    },
-    placemark: {
-      type: "placemark",
-      value: {
-        city: "Westside",
-        isoCountryCode: "USA",
-        name: "420 Hagar Dr, Santa Cruz, CA 95064, United States",
-        postalCode: "95064",
-        street: "Hagar Dr",
-        streetNumber: "420"
-      }
+const santaCruzLocation: TestLocation = {
+  name: "Santa Cruz (West Coast US)",
+  coordinate: {
+    type: "coordinate",
+    value: {
+      latitude: 36.99813840222285,
+      longitude: -122.05564377465653
     }
   },
+  placemark: {
+    type: "placemark",
+    value: {
+      city: "Westside",
+      isoCountryCode: "USA",
+      name: "420 Hagar Dr, Santa Cruz, CA 95064, United States",
+      postalCode: "95064",
+      street: "Hagar Dr",
+      streetNumber: "420"
+    }
+  }
+}
+
+const santaCruzLocation2: TestLocation = {
+  name: "Santa Cruz 2 (West Coast US)",
+  coordinate: {
+    type: "coordinate",
+    value: {
+      latitude: 36.9989943,
+      longitude: -122.0614698
+    }
+  },
+  placemark: {
+    type: "placemark",
+    value: {
+      city: "Westside",
+      isoCountryCode: "USA",
+      name: "Steinhart Way, Santa Cruz, CA 95064, United States",
+      postalCode: "95064",
+      street: "Steinhart Way",
+      region: "California"
+    }
+  }
+}
+
+export const testLocations: TestLocation[] = [
+  santaCruzLocation,
+  santaCruzLocation2,
   {
     name: "New York City (East Coast US)",
     coordinate: {
@@ -139,11 +164,11 @@ describe("Geocoding lambda tests", () => {
   const mockReverseGeocoding = jest.fn()
 
   mockGeocoding.mockImplementation(() => {
-    throw new Error("Error: Should not trigger")
+    throw new Error("Error: Could not find cached location. Triggering forward geocoding")
   })
 
   mockReverseGeocoding.mockImplementation(() => {
-    throw new Error("Error: Should not trigger")
+    throw new Error("Error: Could not find cached location. Triggering reverse geocoding")
   })
 
   beforeEach(async () => {
@@ -181,6 +206,20 @@ describe("Geocoding lambda tests", () => {
         })
       }
     )
+
+    it("Should allow multiple events with a similar address", async () => {
+      const result = (await handler(santaCruzLocation.placemark)).unwrap()
+
+      expect(result).toMatchObject({
+        placemark: santaCruzLocation.placemark.value
+      })
+
+      const result2 = (await handler(santaCruzLocation2.placemark)).unwrap()
+
+      expect(result2).toMatchObject({
+        placemark: santaCruzLocation2.placemark.value
+      })
+    })
 
     it("Should use default coordinates given an unknown address", async () => {
       const result = (await handler(unknownAddressTestLocation.placemark)).unwrap()
@@ -227,6 +266,26 @@ describe("Geocoding lambda tests", () => {
         })
       }
     )
+
+    it("Should allow multiple events with a similar coordinates", async () => {
+      const result = (await handler(santaCruzLocation.coordinate)).unwrap()
+
+      expect(result).toMatchObject({
+        coordinate: {
+          latitude: expect.closeTo(santaCruzLocation.coordinate.value.latitude),
+          longitude: expect.closeTo(santaCruzLocation.coordinate.value.longitude)
+        }
+      })
+
+      const result2 = (await handler(santaCruzLocation2.coordinate)).unwrap()
+
+      expect(result2).toMatchObject({
+        coordinate: {
+          latitude: expect.closeTo(santaCruzLocation2.coordinate.value.latitude),
+          longitude: expect.closeTo(santaCruzLocation2.coordinate.value.longitude)
+        }
+      })
+    })
 
     it("Should use default address given unknown coordinates", async () => {
       const result = (await handler(unknownAddressTestLocation.coordinate)).unwrap()

--- a/GeocodingLambda/utils.ts
+++ b/GeocodingLambda/utils.ts
@@ -111,18 +111,18 @@ export const checkExistingPlacemarkInDB = (
       : conn
         .queryFirstResult<FlattenedLocation>(
           `
-        SELECT * 
-          FROM location
-          WHERE name = :name
-          OR city = :city
-          OR country = :country
-          OR street = :street
-          OR streetNumber = :streetNumber
-          OR postalCode = :postalCode
-          OR region = :region
-          OR isoCountryCode = :isoCountryCode
-          LIMIT 1
-        `,
+          SELECT * 
+            FROM location
+            WHERE COALESCE(name, '') = COALESCE(:name, '')
+              AND COALESCE(city, '') = COALESCE(:city, '')
+              AND COALESCE(country, '') = COALESCE(:country, '')
+              AND COALESCE(street, '') = COALESCE(:street, '')
+              AND COALESCE(streetNumber, '') = COALESCE(:streetNumber, '')
+              AND COALESCE(postalCode, '') = COALESCE(:postalCode, '')
+              AND COALESCE(region, '') = COALESCE(:region, '')
+              AND COALESCE(isoCountryCode, '') = COALESCE(:isoCountryCode, '')
+            LIMIT 1;
+          `,
           {
             name: locationEdit.value.name ?? undefined,
             city: locationEdit.value.city ?? undefined,

--- a/TiFBackendUtils/TiFEventUtils/TiFEventResponse.ts
+++ b/TiFBackendUtils/TiFEventUtils/TiFEventResponse.ts
@@ -123,7 +123,7 @@ export const tifEventResponseFromDatabaseEvent = (
         isoCountryCode: event.isoCountryCode ?? undefined,
         city: event.city ?? undefined
       },
-      timezoneIdentifier: event.timezoneIdentifier ?? "",
+      timezoneIdentifier: event.timezoneIdentifier!, // should never have events without timezones
       arrivalRadiusMeters: ARRIVAL_RADIUS_IN_METERS,
       isInArrivalTrackingPeriod:
         calcSecondsToStart(event.startDateTime) < SECONDS_IN_DAY


### PR DESCRIPTION
Error: Can't save multiple locations in similar areas due to partial matching in the sql that checks for existing placemarks

Solution: Use exact placemark matching.
Note: Needed to COALESCE the given placemark since trying to match NULL always returns false

https://trello.com/c/LyzvT5QG/888-backend