### PR TITLE
SQL query change to switch join

### DIFF
--- a/APILambda/events/upcomingEvents.test.ts
+++ b/APILambda/events/upcomingEvents.test.ts
@@ -151,7 +151,7 @@ describe("upcomingEvents tests", () => {
   })
 
   it("should not load events the user is not attending or hosting", async () => {
-    const nonAttendingUser = await createUserFlow()
+    const attendingUser = await createUserFlow()
     await createEventFlow(
       [
         {
@@ -164,14 +164,14 @@ describe("upcomingEvents tests", () => {
       10
     )
     const resp = await testAPI.upcomingEvents<200>({
-      auth: nonAttendingUser.auth,
-      query: { userId: nonAttendingUser.id }
+      auth: attendingUser.auth,
+      query: { userId: attendingUser.id }
     })
     expect(resp.data.events).toEqual([])
   })
 
   it("should not load events the user is not attending or hosting when they are at least in one event", async () => {
-    const nonAttendingUser = await createUserFlow()
+    const attendingUser = await createUserFlow()
     const { eventIds: [eventId] } =
     await createEventFlow(
       [
@@ -185,15 +185,44 @@ describe("upcomingEvents tests", () => {
       10
     )
     await testAPI.joinEvent<200>({
-      auth: nonAttendingUser.auth,
+      auth: attendingUser.auth,
       params: { eventId }
     })
 
     const resp = await testAPI.upcomingEvents<200>({
-      auth: nonAttendingUser.auth,
-      query: { userId: nonAttendingUser.id }
+      auth: attendingUser.auth,
+      query: { userId: attendingUser.id }
     })
     expect(resp.data.events.map((e) => e.id)).toEqual([eventId])
+  })
+
+  it("should not load other users' events", async () => {
+    const attendingUser = await createUserFlow()
+    const otherUser = await createUserFlow()
+    const attendingEventTitle = "Whatever"
+    const otherUserTitle = "Event"
+
+    await testAPI.createEvent<201>({
+      auth: otherUser.auth,
+      body: {
+        ...testEventInput,
+        title: otherUserTitle,
+        duration: 159
+      }
+    })
+    await testAPI.createEvent<201>({
+      auth: attendingUser.auth,
+      body: {
+        ...testEventInput,
+        title: attendingEventTitle,
+        duration: 132
+      }
+    })
+    const resp = await testAPI.upcomingEvents<200>({
+      auth: attendingUser.auth,
+      query: { userId: attendingUser.id }
+    })
+    expect(resp.data.events.map((e) => e.title)).toEqual([attendingEventTitle])
   })
 
   it("should return user not found when user does not exists", async () => {

--- a/APILambda/events/upcomingEvents.ts
+++ b/APILambda/events/upcomingEvents.ts
@@ -6,10 +6,10 @@ import {
   tifEventResponseFromDatabaseEvent,
   UserEventSQL
 } from "TiFBackendUtils/TiFEventUtils"
+import { userRelations } from "TiFBackendUtils/TiFUserUtils"
 import { resp } from "TiFShared/api"
 import { UserID } from "TiFShared/domain-models/User"
 import { authenticatedEndpoint } from "../auth"
-import { userRelations } from "TiFBackendUtils/TiFUserUtils"
 import { userNotFoundBody } from "../utils/Responses"
 
 const getUpcomingEvents = (
@@ -21,7 +21,7 @@ const getUpcomingEvents = (
     `
     ${UserEventSQL.BASE}
     ${UserEventSQL.ATTENDANCE_INNER_JOIN}
-    ${UserEventSQL.BASE_WHERE}
+    ${UserEventSQL.USER_ATTENDANCE_WHERE}
     ${UserEventSQL.ORDER_BY_START_TIME}
     `,
     {

--- a/TiFBackendUtils/TiFEventUtils/UserEvent.ts
+++ b/TiFBackendUtils/TiFEventUtils/UserEvent.ts
@@ -20,7 +20,7 @@ export namespace UserEventSQL {
       ON UserRelationOfUserToHost.fromUserId = :userId AND UserRelationOfUserToHost.toUserId = TifEventView.hostId
       `
   export const ATTENDANCE_INNER_JOIN =
-    "INNER JOIN eventAttendance ea ON ea.userId = :attendingUserId"
+    "INNER JOIN eventAttendance ea ON ea.eventId = TifEventView.id"
 
   const BASE_WHERE_CLAUSES = `
     TifEventView.endDateTime > NOW()
@@ -32,6 +32,13 @@ export namespace UserEventSQL {
     WHERE
       ${BASE_WHERE_CLAUSES}
     `
+
+  export const USER_ATTENDANCE_WHERE = `
+    WHERE
+    ${BASE_WHERE_CLAUSES}
+    AND ea.userId = :attendingUserId
+    AND ea.role IN ('hosting', 'attending')
+  `
   export const GEOSPATIAL_WHERE = `
     WHERE
       ST_Distance_Sphere(POINT(:userLongitude, :userLatitude), POINT(TifEventView.longitude, TifEventView.latitude)) < :radius


### PR DESCRIPTION

## Problem/Purpose

Adjusts the SQL query to properly query the upcoming events for a specific user.

## Proposed Solution

The specific SQL query was using an inner join, without a properly filtering where clause. This adds a where clause that properly filters out events based on whether or not the specific user is hosting or attending the event.
