### PR TITLE
Fix Duplicate Attendees

### DIFF
--- a/APILambda/events/joinEvent.test.ts
+++ b/APILambda/events/joinEvent.test.ts
@@ -292,4 +292,37 @@ describe("Join the event by id tests", () => {
       data: { error: "event-was-cancelled" }
     })
   })
+
+  test("join event, only lists 1 attendance record for user after arriving at multiple locations", async () => {
+    const user = await createUserFlow()
+    const {
+      eventIds: [eventId]
+    } = await createEventFlow(
+      [{ location: { type: "coordinate", value: eventLocation } }],
+      1
+    )
+    await testAPI.updateArrivalStatus({
+      auth: user.auth,
+      body: {
+        status: "arrived",
+        coordinate: { latitude: -33.86882, longitude: 151.209296 },
+        arrivalRadiusMeters: 200
+      }
+    })
+    await testAPI.joinEvent<201>({
+      auth: user.auth,
+      params: { eventId },
+      body: {
+        region: {
+          coordinate: eventLocation,
+          arrivalRadiusMeters: 200
+        }
+      }
+    })
+    const resp = await testAPI.eventDetails<200>({
+      auth: user.auth,
+      params: { eventId }
+    })
+    expect(resp.data.attendeeCount).toEqual(3)
+  })
 })

--- a/APILambda/events/joinEvent.test.ts
+++ b/APILambda/events/joinEvent.test.ts
@@ -299,7 +299,7 @@ describe("Join the event by id tests", () => {
       eventIds: [eventId]
     } = await createEventFlow(
       [{ location: { type: "coordinate", value: eventLocation } }],
-      1
+      0
     )
     await testAPI.updateArrivalStatus({
       auth: user.auth,
@@ -323,6 +323,6 @@ describe("Join the event by id tests", () => {
       auth: user.auth,
       params: { eventId }
     })
-    expect(resp.data.attendeeCount).toEqual(3)
+    expect(resp.data.attendeeCount).toEqual(2) // NB: Host + User
   })
 })

--- a/APILambda/events/upcomingEvents.test.ts
+++ b/APILambda/events/upcomingEvents.test.ts
@@ -320,13 +320,7 @@ describe("upcomingEvents tests", () => {
         title: "Soccer Game",
         startDateTime,
         duration: 3600,
-        location: {
-          type: "coordinate",
-          value: {
-            latitude: soccerLocation.latitude,
-            longitude: soccerLocation.longitude
-          }
-        }
+        location: { type: "coordinate", value: soccerLocation }
       }
     ])
 
@@ -338,13 +332,7 @@ describe("upcomingEvents tests", () => {
         title: "Basketball Game",
         startDateTime,
         duration: 3600,
-        location: {
-          type: "coordinate",
-          value: {
-            latitude: basketballLocation.latitude,
-            longitude: basketballLocation.longitude
-          }
-        }
+        location: { type: "coordinate", value: basketballLocation }
       }
     ])
 
@@ -362,11 +350,8 @@ describe("upcomingEvents tests", () => {
       auth: attendee.auth,
       body: {
         status: "arrived",
-        coordinate: {
-          latitude: soccerLocation.latitude,
-          longitude: soccerLocation.longitude
-        },
-        arrivalRadiusMeters: 10
+        coordinate: soccerLocation,
+        arrivalRadiusMeters: 100
       }
     })
 
@@ -382,14 +367,8 @@ describe("upcomingEvents tests", () => {
           {
             id: soccerEvent.data.id,
             previewAttendees: [
-              expect.objectContaining({
-                id: soccerHost.id,
-                role: "hosting"
-              }),
-              expect.objectContaining({
-                id: attendee.id,
-                role: "attending"
-              })
+              expect.objectContaining({ id: soccerHost.id, role: "hosting" }),
+              expect.objectContaining({ id: attendee.id, role: "attending" })
             ]
           },
           {
@@ -399,10 +378,7 @@ describe("upcomingEvents tests", () => {
                 id: basketballHost.id,
                 role: "hosting"
               }),
-              expect.objectContaining({
-                id: attendee.id,
-                role: "attending"
-              })
+              expect.objectContaining({ id: attendee.id, role: "attending" })
             ]
           }
         ]

--- a/TiFBackendUtils/TiFEventUtils/EventAttendance.ts
+++ b/TiFBackendUtils/TiFEventUtils/EventAttendance.ts
@@ -57,19 +57,29 @@ const attendees = async (
       u.name,
       u.handle,
       ea.joinedDateTime,
-      ua.arrivedDateTime,
+      (
+        SELECT ua.arrivedDateTime
+        FROM userArrivals AS ua
+        WHERE ua.userId = u.id
+          AND (
+            ST_Distance_Sphere(
+              POINT(ua.longitude, ua.latitude),
+              POINT(e.longitude, e.latitude)
+            ) < 100
+            OR ua.arrivedDateTime IS NULL
+          )
+        LIMIT 1
+      ) AS arrivedDateTime,
       ea.role,
       MAX(CASE WHEN ur.fromUserId = :userId THEN ur.status END) AS fromYouToThem,
-      MAX(CASE WHEN ur.toUserId = :userId THEN ur.status END) AS fromThemToYou,
-      CASE WHEN ua.arrivedDateTime IS NOT NULL THEN true ELSE false END AS hasArrived
+      MAX(CASE WHEN ur.toUserId = :userId THEN ur.status END) AS fromThemToYou
     FROM user AS u
     INNER JOIN eventAttendance AS ea ON u.id = ea.userId
     INNER JOIN event AS e ON ea.eventId = e.id
-    LEFT JOIN userArrivals AS ua ON ua.userId = u.id
     LEFT JOIN userRelationships AS ur
       ON (ur.fromUserId = u.id AND ur.toUserId = :userId) OR (ur.fromUserId = :userId AND ur.toUserId = u.id)
     WHERE e.id IN (:eventIds)
-    GROUP BY eventId, u.id, ua.arrivedDateTime
+    GROUP BY eventId, u.id
     ORDER BY ea.joinedDateTime ASC
   `,
     { eventIds, userId }
@@ -85,7 +95,7 @@ const attendees = async (
           profileImageURL: attendee.profileImageURL,
           handle: attendee.handle,
           arrivedDateTime: attendee.arrivedDateTime,
-          hasArrived: !!attendee.hasArrived,
+          hasArrived: !!attendee.arrivedDateTime,
           role: attendee.role,
           relationStatus: UserRelationsSchema.parse({
             fromYouToThem: attendee.fromYouToThem ?? "not-friends",

--- a/TiFBackendUtils/TiFEventUtils/TiFEventResponse.ts
+++ b/TiFBackendUtils/TiFEventUtils/TiFEventResponse.ts
@@ -92,62 +92,57 @@ export type TiFEvent = {
 
 export const tifEventResponseFromDatabaseEvent = (
   event: DBTifEvent
-): TiFEvent => {
-  console.log("translating event")
-  console.log(event)
-
-  return {
-    id: event.id,
-    title: event.title,
-    description: event.description,
-    attendeeCount: event.attendeeCount,
-    color: event.color,
-    time: {
-      secondsToStart: calcSecondsToStart(event.startDateTime),
-      dateRange: dateRange(event.startDateTime, event.endDateTime)!,
-      todayOrTomorrow: calcTodayOrTomorrow(event.startDateTime)
+): TiFEvent => ({
+  id: event.id,
+  title: event.title,
+  description: event.description,
+  attendeeCount: event.attendeeCount,
+  color: event.color,
+  time: {
+    secondsToStart: calcSecondsToStart(event.startDateTime),
+    dateRange: dateRange(event.startDateTime, event.endDateTime)!,
+    todayOrTomorrow: calcTodayOrTomorrow(event.startDateTime)
+  },
+  previewAttendees: event.previewAttendees,
+  location: {
+    coordinate: {
+      latitude: event.latitude,
+      longitude: event.longitude
     },
-    previewAttendees: event.previewAttendees,
-    location: {
-      coordinate: {
-        latitude: event.latitude,
-        longitude: event.longitude
-      },
-      placemark: {
-        name: event.placemarkName ?? undefined,
-        country: event.country ?? undefined,
-        postalCode: event.postalCode ?? undefined,
-        street: event.street ?? undefined,
-        streetNumber: event.streetNumber ?? undefined,
-        region: event.region ?? undefined,
-        isoCountryCode: event.isoCountryCode ?? undefined,
-        city: event.city ?? undefined
-      },
-      timezoneIdentifier: event.timezoneIdentifier!, // should never have events without timezones
-      arrivalRadiusMeters: ARRIVAL_RADIUS_IN_METERS,
-      isInArrivalTrackingPeriod:
-        calcSecondsToStart(event.startDateTime) < SECONDS_IN_DAY
+    placemark: {
+      name: event.placemarkName ?? undefined,
+      country: event.country ?? undefined,
+      postalCode: event.postalCode ?? undefined,
+      street: event.street ?? undefined,
+      streetNumber: event.streetNumber ?? undefined,
+      region: event.region ?? undefined,
+      isoCountryCode: event.isoCountryCode ?? undefined,
+      city: event.city ?? undefined
     },
-    host: {
-      relationStatus: UserRelationsSchema.parse({
-        fromThemToYou: event.fromThemToYou,
-        fromYouToThem: event.fromYouToThem
-      }) as UnblockedUserRelationsStatus,
-      id: event.hostId,
-      name: event.hostName,
-      handle: event.hostHandle,
-      profileImageURL: undefined
-    },
-    settings: {
-      shouldHideAfterStartDate: event.shouldHideAfterStartDate,
-      isChatEnabled: event.isChatEnabled
-    },
-    userAttendeeStatus: event.userAttendeeStatus,
-    joinedDateTime: event.joinedDateTime,
-    isChatExpired: isDayAfter(event.endedDateTime),
-    hasArrived: event.hasArrived,
-    updatedDateTime: event.updatedDateTime,
-    createdDateTime: event.createdDateTime,
-    endedDateTime: event.endedDateTime
-  }
-}
+    timezoneIdentifier: event.timezoneIdentifier!, // should never have events without timezones
+    arrivalRadiusMeters: ARRIVAL_RADIUS_IN_METERS,
+    isInArrivalTrackingPeriod:
+      calcSecondsToStart(event.startDateTime) < SECONDS_IN_DAY
+  },
+  host: {
+    relationStatus: UserRelationsSchema.parse({
+      fromThemToYou: event.fromThemToYou,
+      fromYouToThem: event.fromYouToThem
+    }) as UnblockedUserRelationsStatus,
+    id: event.hostId,
+    name: event.hostName,
+    handle: event.hostHandle,
+    profileImageURL: undefined
+  },
+  settings: {
+    shouldHideAfterStartDate: event.shouldHideAfterStartDate,
+    isChatEnabled: event.isChatEnabled
+  },
+  userAttendeeStatus: event.userAttendeeStatus,
+  joinedDateTime: event.joinedDateTime,
+  isChatExpired: isDayAfter(event.endedDateTime),
+  hasArrived: event.hasArrived,
+  updatedDateTime: event.updatedDateTime,
+  createdDateTime: event.createdDateTime,
+  endedDateTime: event.endedDateTime
+})


### PR DESCRIPTION
Fixes an issue where duplicate attendees with different arrivals would be listed in the attendees list for an event. Solving this required updating the query for gathering the attendees and removing the join on the user arrivals table. The join would cause each arrival to be paired with each event, even if their locations weren't linked, and trying to filter by location would cause event attendances who have not arrived at the event to be filtered out. To ensure that the arrival information was accurate, I moved the location check into a separate select clause just for selecting `arrivedDateTime`. `hasArrived` is computable based on whether or not we have an `arrivedDateTime`, so there's no need to try to compute it in the SQL.

## Tickets

https://trello.com/c/O2OyGBaV